### PR TITLE
Fix "case-insensitive import collision" Error: "github.com/sirupsen/logrus" and "github.com/Sirupsen/logrus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ docker build -t pumba -f Dockerfile .
 ## Used Libraries and Code
 
 - Official Docker API for Go [docker/docker](https://github.com/docker/docker)
-- Logging  [Sirupsen/logrus](https://github.com/Sirupsen/logrus)
+- Logging  [sirupsen/logrus](https://github.com/sirupsen/logrus)
 - Command line app lib [codegangsta/cli](https://github.com/codegangsta/cli)
 
 I've also borrowed some code from very good [CenturyLinkLabs/watchtower](https://github.com/CenturyLinkLabs/watchtower) project.

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/alexei-led/pumba/container"
 )
 

--- a/container/client.go
+++ b/container/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	types "github.com/docker/docker/api/types"
 	ctypes "github.com/docker/docker/api/types/container"

--- a/glide.lock
+++ b/glide.lock
@@ -54,7 +54,7 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/alexei-led/pumba
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/stretchr/testify
   subpackages:
   - mock

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alexei-led/pumba/action"
 	"github.com/alexei-led/pumba/container"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli"
 

--- a/vendor/github.com/Sirupsen/logrus/README.md
+++ b/vendor/github.com/Sirupsen/logrus/README.md
@@ -1,4 +1,4 @@
-# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/Sirupsen/logrus.svg?branch=master)](https://travis-ci.org/Sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/Sirupsen/logrus?status.svg)](https://godoc.org/github.com/Sirupsen/logrus)
+# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus)&nbsp;[![GoDoc](https://godoc.org/github.com/sirupsen/logrus?status.svg)](https://godoc.org/github.com/sirupsen/logrus)
 
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger. [Godoc][godoc]. **Please note the Logrus API is not
@@ -54,7 +54,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -65,7 +65,7 @@ func main() {
 ```
 
 Note that it's completely api-compatible with the stdlib logger, so you can
-replace your `log` imports everywhere with `log "github.com/Sirupsen/logrus"`
+replace your `log` imports everywhere with `log "github.com/sirupsen/logrus"`
 and you'll now have the flexibility of Logrus. You can customize it all you
 want:
 
@@ -74,7 +74,7 @@ package main
 
 import (
   "os"
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -123,7 +123,7 @@ application, you can also create an instance of the `logrus` Logger:
 package main
 
 import (
-  "github.com/Sirupsen/logrus"
+  "github.com/sirupsen/logrus"
 )
 
 // Create a new instance of the logger. You can have any number of instances.
@@ -176,9 +176,9 @@ Logrus comes with [built-in hooks](hooks/). Add those, or your custom hook, in
 
 ```go
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
   "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "aibrake"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
   "log/syslog"
 )
 
@@ -203,7 +203,7 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [Airbrake](https://github.com/gemnasium/logrus-airbrake-hook) | Send errors to the Airbrake API V3. Uses the official [`gobrake`](https://github.com/airbrake/gobrake) behind the scenes. |
 | [Airbrake "legacy"](https://github.com/gemnasium/logrus-airbrake-legacy-hook) | Send errors to an exception tracking service compatible with the Airbrake API V2. Uses [`airbrake-go`](https://github.com/tobi/airbrake-go) behind the scenes. |
 | [Papertrail](https://github.com/polds/logrus-papertrail-hook) | Send errors to the [Papertrail](https://papertrailapp.com) hosted logging service via UDP. |
-| [Syslog](https://github.com/Sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
+| [Syslog](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | Send errors to remote syslog server. Uses standard library `log/syslog` behind the scenes. |
 | [Bugsnag](https://github.com/Shopify/logrus-bugsnag/blob/master/bugsnag.go) | Send errors to the Bugsnag exception tracking service. |
 | [Sentry](https://github.com/evalphobia/logrus_sentry) | Send errors to the Sentry error logging and aggregation service. |
 | [Hiprus](https://github.com/nubo/hiprus) | Send errors to a channel in hipchat. |
@@ -275,7 +275,7 @@ could do:
 
 ```go
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 init() {

--- a/vendor/github.com/Sirupsen/logrus/doc.go
+++ b/vendor/github.com/Sirupsen/logrus/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
   )
 
   func main() {
@@ -21,6 +21,6 @@ The simplest way to use Logrus is simply the package-level exported logger:
 Output:
   time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
 
-For a full guide visit https://github.com/Sirupsen/logrus
+For a full guide visit https://github.com/sirupsen/logrus
 */
 package logrus

--- a/vendor/github.com/Sirupsen/logrus/examples/basic/basic.go
+++ b/vendor/github.com/Sirupsen/logrus/examples/basic/basic.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var log = logrus.New()

--- a/vendor/github.com/Sirupsen/logrus/examples/hook/hook.go
+++ b/vendor/github.com/Sirupsen/logrus/examples/hook/hook.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/gemnasium/logrus-airbrake-hook.v2"
 )
 

--- a/vendor/github.com/Sirupsen/logrus/formatters/logstash/logstash.go
+++ b/vendor/github.com/Sirupsen/logrus/formatters/logstash/logstash.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Formatter generates json in logstash format.

--- a/vendor/github.com/Sirupsen/logrus/formatters/logstash/logstash_test.go
+++ b/vendor/github.com/Sirupsen/logrus/formatters/logstash/logstash_test.go
@@ -3,7 +3,7 @@ package logstash
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/vendor/github.com/Sirupsen/logrus/hooks/syslog/README.md
+++ b/vendor/github.com/Sirupsen/logrus/hooks/syslog/README.md
@@ -5,8 +5,8 @@
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {
@@ -24,8 +24,8 @@ If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "
 ```go
 import (
   "log/syslog"
-  "github.com/Sirupsen/logrus"
-  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+  "github.com/sirupsen/logrus"
+  logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func main() {

--- a/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog.go
@@ -4,7 +4,7 @@ package logrus_syslog
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"os"
 )

--- a/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog_test.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog_test.go
@@ -1,7 +1,7 @@
 package logrus_syslog
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"log/syslog"
 	"testing"
 )

--- a/vendor/github.com/Sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/test/test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"io/ioutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // test.Hook is a hook designed for dealing with logs in test scenarios.

--- a/vendor/github.com/Sirupsen/logrus/hooks/test/test_test.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/test/test_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/vendor/github.com/Sirupsen/logrus/json_formatter.go
+++ b/vendor/github.com/Sirupsen/logrus/json_formatter.go
@@ -16,7 +16,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
-			// https://github.com/Sirupsen/logrus/issues/137
+			// https://github.com/sirupsen/logrus/issues/137
 			data[k] = v.Error()
 		default:
 			data[k] = v

--- a/vendor/github.com/docker/distribution/BUILDING.md
+++ b/vendor/github.com/docker/distribution/BUILDING.md
@@ -85,7 +85,7 @@ build:
     + lint
     + build
     github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar
-    github.com/Sirupsen/logrus
+    github.com/sirupsen/logrus
     github.com/docker/libtrust
     ...
     github.com/yvasiyarov/gorelic

--- a/vendor/github.com/docker/distribution/Godeps/Godeps.json
+++ b/vendor/github.com/docker/distribution/Godeps/Godeps.json
@@ -12,12 +12,12 @@
 			"Rev": "95361a2573b1fa92a00c5fc2707a80308483c6f9"
 		},
 		{
-			"ImportPath": "github.com/Sirupsen/logrus",
+			"ImportPath": "github.com/sirupsen/logrus",
 			"Comment": "v0.7.3",
 			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
 		},
 		{
-			"ImportPath": "github.com/Sirupsen/logrus/formatters/logstash",
+			"ImportPath": "github.com/sirupsen/logrus/formatters/logstash",
 			"Comment": "v0.7.3",
 			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
 		},

--- a/vendor/github.com/docker/distribution/configuration/parser.go
+++ b/vendor/github.com/docker/distribution/configuration/parser.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 

--- a/vendor/github.com/docker/distribution/context/http.go
+++ b/vendor/github.com/docker/distribution/context/http.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/distribution/uuid"
 	"github.com/gorilla/mux"
 )

--- a/vendor/github.com/docker/distribution/context/logger.go
+++ b/vendor/github.com/docker/distribution/context/logger.go
@@ -3,7 +3,7 @@ package context
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"runtime"
 )
 

--- a/vendor/github.com/docker/distribution/contrib/token-server/main.go
+++ b/vendor/github.com/docker/distribution/contrib/token-server/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/auth"

--- a/vendor/github.com/docker/distribution/manifest/schema1/verify.go
+++ b/vendor/github.com/docker/distribution/manifest/schema1/verify.go
@@ -3,7 +3,7 @@ package schema1
 import (
 	"crypto/x509"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/libtrust"
 )
 

--- a/vendor/github.com/docker/distribution/notifications/sinks.go
+++ b/vendor/github.com/docker/distribution/notifications/sinks.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // NOTE(stevvooe): This file contains definitions for several utility sinks.

--- a/vendor/github.com/docker/distribution/notifications/sinks_test.go
+++ b/vendor/github.com/docker/distribution/notifications/sinks_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"testing"
 )

--- a/vendor/github.com/docker/distribution/registry/auth/token/token.go
+++ b/vendor/github.com/docker/distribution/registry/auth/token/token.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/libtrust"
 
 	"github.com/docker/distribution/registry/auth"

--- a/vendor/github.com/docker/distribution/registry/client/auth/session.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/session.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/transport"
 )

--- a/vendor/github.com/docker/distribution/registry/handlers/app.go
+++ b/vendor/github.com/docker/distribution/registry/handlers/app.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	ctxu "github.com/docker/distribution/context"

--- a/vendor/github.com/docker/distribution/registry/handlers/hooks.go
+++ b/vendor/github.com/docker/distribution/registry/handlers/hooks.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // logHook is for hooking Panic in web application

--- a/vendor/github.com/docker/distribution/registry/registry.go
+++ b/vendor/github.com/docker/distribution/registry/registry.go
@@ -11,8 +11,8 @@ import (
 
 	"rsc.io/letsencrypt"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/Sirupsen/logrus/formatters/logstash"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/formatters/logstash"
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"

--- a/vendor/github.com/docker/distribution/registry/storage/blobwriter.go
+++ b/vendor/github.com/docker/distribution/registry/storage/blobwriter.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"

--- a/vendor/github.com/docker/distribution/registry/storage/blobwriter_resumable.go
+++ b/vendor/github.com/docker/distribution/registry/storage/blobwriter_resumable.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/stevvooe/resumable"

--- a/vendor/github.com/docker/distribution/registry/storage/driver/gcs/gcs.go
+++ b/vendor/github.com/docker/distribution/registry/storage/driver/gcs/gcs.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/cloud"
 	"google.golang.org/cloud/storage"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	ctx "github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"

--- a/vendor/github.com/docker/distribution/registry/storage/driver/oss/oss.go
+++ b/vendor/github.com/docker/distribution/registry/storage/driver/oss/oss.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/docker/distribution/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/denverdino/aliyungo/oss"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/base"

--- a/vendor/github.com/docker/distribution/registry/storage/purgeuploads.go
+++ b/vendor/github.com/docker/distribution/registry/storage/purgeuploads.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/distribution/context"
 	storageDriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/uuid"

--- a/vendor/github.com/docker/docker/api/common.go
+++ b/vendor/github.com/docker/docker/api/common.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/system"

--- a/vendor/github.com/docker/docker/api/server/httputils/errors.go
+++ b/vendor/github.com/docker/docker/api/server/httputils/errors.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/gorilla/mux"

--- a/vendor/github.com/docker/docker/api/server/middleware.go
+++ b/vendor/github.com/docker/docker/api/server/middleware.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
 )

--- a/vendor/github.com/docker/docker/api/server/middleware/cors.go
+++ b/vendor/github.com/docker/docker/api/server/middleware/cors.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/vendor/github.com/docker/docker/api/server/middleware/debug.go
+++ b/vendor/github.com/docker/docker/api/server/middleware/debug.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"

--- a/vendor/github.com/docker/docker/api/server/router/build/build_routes.go
+++ b/vendor/github.com/docker/docker/api/server/router/build/build_routes.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/vendor/github.com/docker/docker/api/server/router/container/container_routes.go
+++ b/vendor/github.com/docker/docker/api/server/router/container/container_routes.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/vendor/github.com/docker/docker/api/server/router/container/exec.go
+++ b/vendor/github.com/docker/docker/api/server/router/container/exec.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"

--- a/vendor/github.com/docker/docker/api/server/router/swarm/cluster_routes.go
+++ b/vendor/github.com/docker/docker/api/server/router/swarm/cluster_routes.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/server/httputils"
 	basictypes "github.com/docker/docker/api/types"

--- a/vendor/github.com/docker/docker/api/server/router/system/system_routes.go
+++ b/vendor/github.com/docker/docker/api/server/router/system/system_routes.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/server/httputils"

--- a/vendor/github.com/docker/docker/api/server/server.go
+++ b/vendor/github.com/docker/docker/api/server/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"

--- a/vendor/github.com/docker/docker/builder/dockerfile/builder.go
+++ b/vendor/github.com/docker/docker/builder/dockerfile/builder.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/vendor/github.com/docker/docker/builder/dockerfile/dispatchers.go
+++ b/vendor/github.com/docker/docker/builder/dockerfile/dispatchers.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/builder/dockerfile/internals.go
+++ b/vendor/github.com/docker/docker/builder/dockerfile/internals.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/cli/command/container/attach.go
+++ b/vendor/github.com/docker/docker/cli/command/container/attach.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http/httputil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cli/command/container/exec.go
+++ b/vendor/github.com/docker/docker/cli/command/container/exec.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cli/command/container/hijack.go
+++ b/vendor/github.com/docker/docker/cli/command/container/hijack.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/pkg/stdcopy"

--- a/vendor/github.com/docker/docker/cli/command/container/run.go
+++ b/vendor/github.com/docker/docker/cli/command/container/run.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cli/command/container/stats_helpers.go
+++ b/vendor/github.com/docker/docker/cli/command/container/stats_helpers.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/command/formatter"
 	"github.com/docker/docker/client"

--- a/vendor/github.com/docker/docker/cli/command/container/tty.go
+++ b/vendor/github.com/docker/docker/cli/command/container/tty.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/client"

--- a/vendor/github.com/docker/docker/cli/command/container/utils.go
+++ b/vendor/github.com/docker/docker/cli/command/container/utils.go
@@ -3,7 +3,7 @@ package container
 import (
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"

--- a/vendor/github.com/docker/docker/cli/command/events_utils.go
+++ b/vendor/github.com/docker/docker/cli/command/events_utils.go
@@ -3,7 +3,7 @@ package command
 import (
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	eventtypes "github.com/docker/docker/api/types/events"
 )
 

--- a/vendor/github.com/docker/docker/cli/command/image/trust.go
+++ b/vendor/github.com/docker/docker/cli/command/image/trust.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"sort"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cli/command/inspect/inspector.go
+++ b/vendor/github.com/docker/docker/cli/command/inspect/inspector.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/templates"
 )

--- a/vendor/github.com/docker/docker/cli/command/out.go
+++ b/vendor/github.com/docker/docker/cli/command/out.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/term"
 )
 

--- a/vendor/github.com/docker/docker/cli/command/plugin/create.go
+++ b/vendor/github.com/docker/docker/cli/command/plugin/create.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cli/command/service/trust.go
+++ b/vendor/github.com/docker/docker/cli/command/service/trust.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/swarm"

--- a/vendor/github.com/docker/docker/cli/flags/common.go
+++ b/vendor/github.com/docker/docker/cli/flags/common.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	cliconfig "github.com/docker/docker/cli/config"
 	"github.com/docker/docker/opts"
 	"github.com/docker/go-connections/tlsconfig"

--- a/vendor/github.com/docker/docker/cli/trust/trust.go
+++ b/vendor/github.com/docker/docker/cli/trust/trust.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"

--- a/vendor/github.com/docker/docker/cmd/docker/docker.go
+++ b/vendor/github.com/docker/docker/cmd/docker/docker.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"

--- a/vendor/github.com/docker/docker/cmd/docker/docker_test.go
+++ b/vendor/github.com/docker/docker/cmd/docker/docker_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/debug"
 	"github.com/docker/docker/pkg/testutil/assert"

--- a/vendor/github.com/docker/docker/cmd/dockerd/daemon.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/daemon.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/uuid"
 	"github.com/docker/docker/api"
 	apiserver "github.com/docker/docker/api/server"

--- a/vendor/github.com/docker/docker/cmd/dockerd/daemon_test.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/daemon_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	cliflags "github.com/docker/docker/cli/flags"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/testutil/assert"

--- a/vendor/github.com/docker/docker/cmd/dockerd/daemon_windows.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/daemon_windows.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/system"
 )

--- a/vendor/github.com/docker/docker/cmd/dockerd/docker.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/docker.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/cli"
 	cliflags "github.com/docker/docker/cli/flags"
 	"github.com/docker/docker/daemon"

--- a/vendor/github.com/docker/docker/cmd/dockerd/metrics.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/metrics.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	metrics "github.com/docker/go-metrics"
 )
 

--- a/vendor/github.com/docker/docker/cmd/dockerd/service_windows.go
+++ b/vendor/github.com/docker/docker/cmd/dockerd/service_windows.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"

--- a/vendor/github.com/docker/docker/container/container.go
+++ b/vendor/github.com/docker/docker/container/container.go
@@ -15,7 +15,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	networktypes "github.com/docker/docker/api/types/network"

--- a/vendor/github.com/docker/docker/container/container_unix.go
+++ b/vendor/github.com/docker/docker/container/container_unix.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/chrootarchive"

--- a/vendor/github.com/docker/docker/container/health.go
+++ b/vendor/github.com/docker/docker/container/health.go
@@ -1,7 +1,7 @@
 package container
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 )
 

--- a/vendor/github.com/docker/docker/container/monitor.go
+++ b/vendor/github.com/docker/docker/container/monitor.go
@@ -3,7 +3,7 @@ package container
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/vendor/github.com/docker/docker/container/stream/streams.go
+++ b/vendor/github.com/docker/docker/container/stream/streams.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/broadcaster"
 	"github.com/docker/docker/pkg/ioutils"

--- a/vendor/github.com/docker/docker/contrib/docker-device-tool/device_tool.go
+++ b/vendor/github.com/docker/docker/contrib/docker-device-tool/device_tool.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver/devmapper"
 	"github.com/docker/docker/pkg/devicemapper"
 )

--- a/vendor/github.com/docker/docker/daemon/attach.go
+++ b/vendor/github.com/docker/docker/daemon/attach.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"

--- a/vendor/github.com/docker/docker/daemon/cache.go
+++ b/vendor/github.com/docker/docker/daemon/cache.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/dockerversion"

--- a/vendor/github.com/docker/docker/daemon/cluster/cluster.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/cluster.go
@@ -51,7 +51,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
 	apierrors "github.com/docker/docker/api/errors"

--- a/vendor/github.com/docker/docker/daemon/cluster/convert/container.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/convert/container.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	container "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	types "github.com/docker/docker/api/types/swarm"

--- a/vendor/github.com/docker/docker/daemon/cluster/executor/container/adapter.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/executor/container/adapter.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/vendor/github.com/docker/docker/daemon/cluster/executor/container/container.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/executor/container/container.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/api/types"
 	enginecontainer "github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/daemon/cluster/noderunner.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/noderunner.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/executor/container"
 	swarmapi "github.com/docker/swarmkit/api"

--- a/vendor/github.com/docker/docker/daemon/config.go
+++ b/vendor/github.com/docker/docker/daemon/config.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/docker/registry"

--- a/vendor/github.com/docker/docker/daemon/container_operations.go
+++ b/vendor/github.com/docker/docker/daemon/container_operations.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	derr "github.com/docker/docker/api/errors"
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"

--- a/vendor/github.com/docker/docker/daemon/container_operations_unix.go
+++ b/vendor/github.com/docker/docker/daemon/container_operations_unix.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/links"

--- a/vendor/github.com/docker/docker/daemon/create.go
+++ b/vendor/github.com/docker/docker/daemon/create.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/daemon/create_unix.go
+++ b/vendor/github.com/docker/docker/daemon/create_unix.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"

--- a/vendor/github.com/docker/docker/daemon/daemon.go
+++ b/vendor/github.com/docker/docker/daemon/daemon.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"

--- a/vendor/github.com/docker/docker/daemon/daemon_linux.go
+++ b/vendor/github.com/docker/docker/daemon/daemon_linux.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/mount"
 )
 

--- a/vendor/github.com/docker/docker/daemon/daemon_solaris.go
+++ b/vendor/github.com/docker/docker/daemon/daemon_solaris.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"

--- a/vendor/github.com/docker/docker/daemon/daemon_unix.go
+++ b/vendor/github.com/docker/docker/daemon/daemon_unix.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/blkiodev"
 	pblkiodev "github.com/docker/docker/api/types/blkiodev"

--- a/vendor/github.com/docker/docker/daemon/daemon_windows.go
+++ b/vendor/github.com/docker/docker/daemon/daemon_windows.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"

--- a/vendor/github.com/docker/docker/daemon/debugtrap_unix.go
+++ b/vendor/github.com/docker/docker/daemon/debugtrap_unix.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	stackdump "github.com/docker/docker/pkg/signal"
 )
 

--- a/vendor/github.com/docker/docker/daemon/debugtrap_windows.go
+++ b/vendor/github.com/docker/docker/daemon/debugtrap_windows.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 
 	winio "github.com/Microsoft/go-winio"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/system"
 )

--- a/vendor/github.com/docker/docker/daemon/delete.go
+++ b/vendor/github.com/docker/docker/daemon/delete.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"

--- a/vendor/github.com/docker/docker/daemon/discovery.go
+++ b/vendor/github.com/docker/docker/daemon/discovery.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 
 	// Register the libkv backends for discovery.

--- a/vendor/github.com/docker/docker/daemon/disk_usage.go
+++ b/vendor/github.com/docker/docker/daemon/disk_usage.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/vendor/github.com/docker/docker/daemon/exec.go
+++ b/vendor/github.com/docker/docker/daemon/exec.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/strslice"

--- a/vendor/github.com/docker/docker/daemon/exec/exec.go
+++ b/vendor/github.com/docker/docker/daemon/exec/exec.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container/stream"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/stringid"

--- a/vendor/github.com/docker/docker/daemon/getsize_unix.go
+++ b/vendor/github.com/docker/docker/daemon/getsize_unix.go
@@ -3,7 +3,7 @@
 package daemon
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container"
 )
 

--- a/vendor/github.com/docker/docker/daemon/graphdriver/aufs/aufs.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/aufs/aufs.go
@@ -36,7 +36,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
 
 	"github.com/docker/docker/daemon/graphdriver"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/aufs/mount.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/aufs/mount.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Unmount the target specified.

--- a/vendor/github.com/docker/docker/daemon/graphdriver/devmapper/deviceset.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/devmapper/deviceset.go
@@ -19,7 +19,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/dockerversion"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/devmapper/driver.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/devmapper/driver.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/devicemapper"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/driver.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/driver.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
 
 	"github.com/docker/docker/pkg/archive"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/driver_solaris.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/driver_solaris.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/mount"
 )
 

--- a/vendor/github.com/docker/docker/daemon/graphdriver/fsdiff.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/fsdiff.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/overlay/overlay.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/overlay/overlay.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"
 	"github.com/docker/docker/pkg/archive"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/check.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/check.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 )

--- a/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/overlay.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/overlay.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/randomid.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/overlay2/randomid.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // generateID creates a new random string identifier with the given length

--- a/vendor/github.com/docker/docker/daemon/graphdriver/quota/projectquota.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/quota/projectquota.go
@@ -58,7 +58,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Quota limit params - currently we only control blocks hard limit

--- a/vendor/github.com/docker/docker/daemon/graphdriver/windows/windows.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/windows/windows.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Microsoft/go-winio/archive/tar"
 	"github.com/Microsoft/go-winio/backuptar"
 	"github.com/Microsoft/hcsshim"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"

--- a/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_freebsd.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_freebsd.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 )
 

--- a/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_linux.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 )
 

--- a/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_solaris.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/zfs/zfs_solaris.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 )
 

--- a/vendor/github.com/docker/docker/daemon/health.go
+++ b/vendor/github.com/docker/docker/daemon/health.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"

--- a/vendor/github.com/docker/docker/daemon/info.go
+++ b/vendor/github.com/docker/docker/daemon/info.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/debug"

--- a/vendor/github.com/docker/docker/daemon/info_unix.go
+++ b/vendor/github.com/docker/docker/daemon/info_unix.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/sysinfo"

--- a/vendor/github.com/docker/docker/daemon/kill.go
+++ b/vendor/github.com/docker/docker/daemon/kill.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/signal"
 )

--- a/vendor/github.com/docker/docker/daemon/links_linux.go
+++ b/vendor/github.com/docker/docker/daemon/links_linux.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/graphdb"
 )

--- a/vendor/github.com/docker/docker/daemon/list.go
+++ b/vendor/github.com/docker/docker/daemon/list.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	networktypes "github.com/docker/docker/api/types/network"

--- a/vendor/github.com/docker/docker/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/vendor/github.com/docker/docker/daemon/logger/awslogs/cloudwatchlogs.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"

--- a/vendor/github.com/docker/docker/daemon/logger/copier.go
+++ b/vendor/github.com/docker/docker/daemon/logger/copier.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/vendor/github.com/docker/docker/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/vendor/github.com/docker/docker/daemon/logger/etwlogs/etwlogs_windows.go
@@ -19,7 +19,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"golang.org/x/sys/windows"
 )

--- a/vendor/github.com/docker/docker/daemon/logger/fluentd/fluentd.go
+++ b/vendor/github.com/docker/docker/daemon/logger/fluentd/fluentd.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/urlutil"

--- a/vendor/github.com/docker/docker/daemon/logger/gcplogs/gcplogging.go
+++ b/vendor/github.com/docker/docker/daemon/logger/gcplogs/gcplogging.go
@@ -10,7 +10,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/logging"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/vendor/github.com/docker/docker/daemon/logger/gcplogs/gcplogging_linux.go
+++ b/vendor/github.com/docker/docker/daemon/logger/gcplogs/gcplogging_linux.go
@@ -5,7 +5,7 @@ package gcplogs
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/homedir"
 )

--- a/vendor/github.com/docker/docker/daemon/logger/gelf/gelf.go
+++ b/vendor/github.com/docker/docker/daemon/logger/gelf/gelf.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Graylog2/go-gelf/gelf"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/urlutil"

--- a/vendor/github.com/docker/docker/daemon/logger/journald/journald.go
+++ b/vendor/github.com/docker/docker/daemon/logger/journald/journald.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/coreos/go-systemd/journal"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"

--- a/vendor/github.com/docker/docker/daemon/logger/journald/read.go
+++ b/vendor/github.com/docker/docker/daemon/logger/journald/read.go
@@ -155,7 +155,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/coreos/go-systemd/journal"
 	"github.com/docker/docker/daemon/logger"
 )

--- a/vendor/github.com/docker/docker/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/vendor/github.com/docker/docker/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/jsonlog"

--- a/vendor/github.com/docker/docker/daemon/logger/jsonfilelog/read.go
+++ b/vendor/github.com/docker/docker/daemon/logger/jsonfilelog/read.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/pkg/filenotify"
 	"github.com/docker/docker/pkg/ioutils"

--- a/vendor/github.com/docker/docker/daemon/logger/logentries/logentries.go
+++ b/vendor/github.com/docker/docker/daemon/logger/logentries/logentries.go
@@ -5,7 +5,7 @@ package logentries
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/bsphere/le_go"
 	"github.com/docker/docker/daemon/logger"
 )

--- a/vendor/github.com/docker/docker/daemon/logger/splunk/splunk.go
+++ b/vendor/github.com/docker/docker/daemon/logger/splunk/splunk.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/urlutil"

--- a/vendor/github.com/docker/docker/daemon/logger/syslog/syslog.go
+++ b/vendor/github.com/docker/docker/daemon/logger/syslog/syslog.go
@@ -14,7 +14,7 @@ import (
 
 	syslog "github.com/RackSec/srslog"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/urlutil"

--- a/vendor/github.com/docker/docker/daemon/logs.go
+++ b/vendor/github.com/docker/docker/daemon/logs.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	timetypes "github.com/docker/docker/api/types/time"

--- a/vendor/github.com/docker/docker/daemon/monitor.go
+++ b/vendor/github.com/docker/docker/daemon/monitor.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/restartmanager"

--- a/vendor/github.com/docker/docker/daemon/names.go
+++ b/vendor/github.com/docker/docker/daemon/names.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/namesgenerator"

--- a/vendor/github.com/docker/docker/daemon/network.go
+++ b/vendor/github.com/docker/docker/daemon/network.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"

--- a/vendor/github.com/docker/docker/daemon/oci_linux.go
+++ b/vendor/github.com/docker/docker/daemon/oci_linux.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/caps"

--- a/vendor/github.com/docker/docker/daemon/prune.go
+++ b/vendor/github.com/docker/docker/daemon/prune.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/vendor/github.com/docker/docker/daemon/rename.go
+++ b/vendor/github.com/docker/docker/daemon/rename.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	dockercontainer "github.com/docker/docker/container"
 	"github.com/docker/libnetwork"
 )

--- a/vendor/github.com/docker/docker/daemon/restart.go
+++ b/vendor/github.com/docker/docker/daemon/restart.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container"
 )
 

--- a/vendor/github.com/docker/docker/daemon/seccomp_linux.go
+++ b/vendor/github.com/docker/docker/daemon/seccomp_linux.go
@@ -5,7 +5,7 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/profiles/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"

--- a/vendor/github.com/docker/docker/daemon/secrets.go
+++ b/vendor/github.com/docker/docker/daemon/secrets.go
@@ -1,7 +1,7 @@
 package daemon
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/swarmkit/agent/exec"
 )

--- a/vendor/github.com/docker/docker/daemon/start.go
+++ b/vendor/github.com/docker/docker/daemon/start.go
@@ -10,7 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/daemon/stats_collector.go
+++ b/vendor/github.com/docker/docker/daemon/stats_collector.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/pubsub"

--- a/vendor/github.com/docker/docker/daemon/stop.go
+++ b/vendor/github.com/docker/docker/daemon/stop.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/container"
 )

--- a/vendor/github.com/docker/docker/daemon/volumes.go
+++ b/vendor/github.com/docker/docker/daemon/volumes.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	dockererrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/distribution/errors.go
+++ b/vendor/github.com/docker/docker/distribution/errors.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"

--- a/vendor/github.com/docker/docker/distribution/pull.go
+++ b/vendor/github.com/docker/docker/distribution/pull.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/distribution/metadata"

--- a/vendor/github.com/docker/docker/distribution/pull_v1.go
+++ b/vendor/github.com/docker/docker/distribution/pull_v1.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"

--- a/vendor/github.com/docker/docker/distribution/pull_v2.go
+++ b/vendor/github.com/docker/docker/distribution/pull_v2.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/manifestlist"

--- a/vendor/github.com/docker/docker/distribution/pull_v2_windows.go
+++ b/vendor/github.com/docker/docker/distribution/pull_v2_windows.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema2"

--- a/vendor/github.com/docker/docker/distribution/push.go
+++ b/vendor/github.com/docker/docker/distribution/push.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/reference"

--- a/vendor/github.com/docker/docker/distribution/push_v1.go
+++ b/vendor/github.com/docker/docker/distribution/push_v1.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"

--- a/vendor/github.com/docker/docker/distribution/push_v2.go
+++ b/vendor/github.com/docker/docker/distribution/push_v2.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"

--- a/vendor/github.com/docker/docker/distribution/registry_unit_test.go
+++ b/vendor/github.com/docker/docker/distribution/registry_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/archive"

--- a/vendor/github.com/docker/docker/distribution/utils/progress.go
+++ b/vendor/github.com/docker/docker/distribution/utils/progress.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 )

--- a/vendor/github.com/docker/docker/distribution/xfer/download.go
+++ b/vendor/github.com/docker/docker/distribution/xfer/download.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"

--- a/vendor/github.com/docker/docker/distribution/xfer/upload.go
+++ b/vendor/github.com/docker/docker/distribution/xfer/upload.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"

--- a/vendor/github.com/docker/docker/image/fs.go
+++ b/vendor/github.com/docker/docker/image/fs.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/pkg/ioutils"
 )

--- a/vendor/github.com/docker/docker/image/rootfs.go
+++ b/vendor/github.com/docker/docker/image/rootfs.go
@@ -3,7 +3,7 @@ package image
 import (
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/layer"
 )
 

--- a/vendor/github.com/docker/docker/image/store.go
+++ b/vendor/github.com/docker/docker/image/store.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/layer"
 )

--- a/vendor/github.com/docker/docker/image/tarexport/load.go
+++ b/vendor/github.com/docker/docker/image/tarexport/load.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/image"

--- a/vendor/github.com/docker/docker/image/v1/imagev1.go
+++ b/vendor/github.com/docker/docker/image/v1/imagev1.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/image"

--- a/vendor/github.com/docker/docker/integration-cli/events_utils_test.go
+++ b/vendor/github.com/docker/docker/integration-cli/events_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"

--- a/vendor/github.com/docker/docker/layer/filestore.go
+++ b/vendor/github.com/docker/docker/layer/filestore.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/pkg/ioutils"

--- a/vendor/github.com/docker/docker/layer/layer.go
+++ b/vendor/github.com/docker/docker/layer/layer.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/pkg/archive"

--- a/vendor/github.com/docker/docker/layer/layer_store.go
+++ b/vendor/github.com/docker/docker/layer/layer_store.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/daemon/graphdriver"

--- a/vendor/github.com/docker/docker/layer/layer_windows.go
+++ b/vendor/github.com/docker/docker/layer/layer_windows.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/daemon/graphdriver"
 )

--- a/vendor/github.com/docker/docker/layer/migration.go
+++ b/vendor/github.com/docker/docker/layer/migration.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"

--- a/vendor/github.com/docker/docker/libcontainerd/client_linux.go
+++ b/vendor/github.com/docker/docker/libcontainerd/client_linux.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/mount"

--- a/vendor/github.com/docker/docker/libcontainerd/client_unix.go
+++ b/vendor/github.com/docker/docker/libcontainerd/client_unix.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/docker/pkg/idtools"
 	specs "github.com/opencontainers/runtime-spec/specs-go"

--- a/vendor/github.com/docker/docker/libcontainerd/client_windows.go
+++ b/vendor/github.com/docker/docker/libcontainerd/client_windows.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/sysinfo"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/vendor/github.com/docker/docker/libcontainerd/container_unix.go
+++ b/vendor/github.com/docker/docker/libcontainerd/container_unix.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/docker/pkg/ioutils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"

--- a/vendor/github.com/docker/docker/libcontainerd/container_windows.go
+++ b/vendor/github.com/docker/docker/libcontainerd/container_windows.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/vendor/github.com/docker/docker/libcontainerd/oom_linux.go
+++ b/vendor/github.com/docker/docker/libcontainerd/oom_linux.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/system"
 )
 

--- a/vendor/github.com/docker/docker/libcontainerd/remote_unix.go
+++ b/vendor/github.com/docker/docker/libcontainerd/remote_unix.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/docker/pkg/system"

--- a/vendor/github.com/docker/docker/migrate/v1/migratev1.go
+++ b/vendor/github.com/docker/docker/migrate/v1/migratev1.go
@@ -13,7 +13,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/image"

--- a/vendor/github.com/docker/docker/pkg/archive/archive.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"

--- a/vendor/github.com/docker/docker/pkg/archive/changes.go
+++ b/vendor/github.com/docker/docker/pkg/archive/changes.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/system"

--- a/vendor/github.com/docker/docker/pkg/archive/copy.go
+++ b/vendor/github.com/docker/docker/pkg/archive/copy.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/system"
 )
 

--- a/vendor/github.com/docker/docker/pkg/archive/diff.go
+++ b/vendor/github.com/docker/docker/pkg/archive/diff.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/system"

--- a/vendor/github.com/docker/docker/pkg/archive/example_changes.go
+++ b/vendor/github.com/docker/docker/pkg/archive/example_changes.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/archive"
 )
 

--- a/vendor/github.com/docker/docker/pkg/authorization/authz.go
+++ b/vendor/github.com/docker/docker/pkg/authorization/authz.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/ioutils"
 )
 

--- a/vendor/github.com/docker/docker/pkg/authorization/middleware.go
+++ b/vendor/github.com/docker/docker/pkg/authorization/middleware.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugingetter"
 	"golang.org/x/net/context"
 )

--- a/vendor/github.com/docker/docker/pkg/authorization/response.go
+++ b/vendor/github.com/docker/docker/pkg/authorization/response.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // ResponseModifier allows authorization plugins to read and modify the content of the http.response

--- a/vendor/github.com/docker/docker/pkg/devicemapper/devmapper.go
+++ b/vendor/github.com/docker/docker/pkg/devicemapper/devmapper.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // DevmapperLogger defines methods for logging with devicemapper.

--- a/vendor/github.com/docker/docker/pkg/discovery/backends.go
+++ b/vendor/github.com/docker/docker/pkg/discovery/backends.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/vendor/github.com/docker/docker/pkg/discovery/kv/kv.go
+++ b/vendor/github.com/docker/docker/pkg/discovery/kv/kv.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/libkv"

--- a/vendor/github.com/docker/docker/pkg/filenotify/poller.go
+++ b/vendor/github.com/docker/docker/pkg/filenotify/poller.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/fsnotify/fsnotify"
 )

--- a/vendor/github.com/docker/docker/pkg/fileutils/fileutils.go
+++ b/vendor/github.com/docker/docker/pkg/fileutils/fileutils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/scanner"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // exclusion returns true if the specified pattern is an exclusion

--- a/vendor/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
+++ b/vendor/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // GetTotalUsedFds Returns the number of used File Descriptors by

--- a/vendor/github.com/docker/docker/pkg/httputils/resumablerequestreader.go
+++ b/vendor/github.com/docker/docker/pkg/httputils/resumablerequestreader.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type resumableRequestReader struct {

--- a/vendor/github.com/docker/docker/pkg/listeners/listeners_unix.go
+++ b/vendor/github.com/docker/docker/pkg/listeners/listeners_unix.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
 	"github.com/docker/go-connections/sockets"
 )

--- a/vendor/github.com/docker/docker/pkg/loopback/attach_loopback.go
+++ b/vendor/github.com/docker/docker/pkg/loopback/attach_loopback.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Loopback related errors

--- a/vendor/github.com/docker/docker/pkg/loopback/loopback.go
+++ b/vendor/github.com/docker/docker/pkg/loopback/loopback.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func getLoopbackBackingFile(file *os.File) (uint64, uint64, error) {

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_unix.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_unix.go
@@ -7,7 +7,7 @@ package kernel
 import (
 	"bytes"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // GetKernelVersion gets the current kernel version.

--- a/vendor/github.com/docker/docker/pkg/platform/platform.go
+++ b/vendor/github.com/docker/docker/pkg/platform/platform.go
@@ -3,7 +3,7 @@ package platform
 import (
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/vendor/github.com/docker/docker/pkg/plugins/client.go
+++ b/vendor/github.com/docker/docker/pkg/plugins/client.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins/transport"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"

--- a/vendor/github.com/docker/docker/pkg/plugins/plugins.go
+++ b/vendor/github.com/docker/docker/pkg/plugins/plugins.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/go-connections/tlsconfig"
 )
 

--- a/vendor/github.com/docker/docker/pkg/signal/trap.go
+++ b/vendor/github.com/docker/docker/pkg/signal/trap.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 

--- a/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_linux.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_linux.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -4,7 +4,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/vendor/github.com/docker/docker/pkg/term/windows/windows.go
+++ b/vendor/github.com/docker/docker/pkg/term/windows/windows.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	ansiterm "github.com/Azure/go-ansiterm"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger

--- a/vendor/github.com/docker/docker/plugin/backend_linux.go
+++ b/vendor/github.com/docker/docker/plugin/backend_linux.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/types"

--- a/vendor/github.com/docker/docker/plugin/blobstore.go
+++ b/vendor/github.com/docker/docker/plugin/blobstore.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/image"

--- a/vendor/github.com/docker/docker/plugin/manager.go
+++ b/vendor/github.com/docker/docker/plugin/manager.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/image"

--- a/vendor/github.com/docker/docker/plugin/manager_linux.go
+++ b/vendor/github.com/docker/docker/plugin/manager_linux.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/initlayer"

--- a/vendor/github.com/docker/docker/plugin/store.go
+++ b/vendor/github.com/docker/docker/plugin/store.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/plugin/v2"

--- a/vendor/github.com/docker/docker/registry/auth.go
+++ b/vendor/github.com/docker/docker/registry/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"

--- a/vendor/github.com/docker/docker/registry/endpoint_v1.go
+++ b/vendor/github.com/docker/docker/registry/endpoint_v1.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/transport"
 	registrytypes "github.com/docker/docker/api/types/registry"
 )

--- a/vendor/github.com/docker/docker/registry/registry.go
+++ b/vendor/github.com/docker/docker/registry/registry.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"

--- a/vendor/github.com/docker/docker/registry/registry_mock_test.go
+++ b/vendor/github.com/docker/docker/registry/registry_mock_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/docker/reference"
 	"github.com/gorilla/mux"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/vendor/github.com/docker/docker/registry/service.go
+++ b/vendor/github.com/docker/docker/registry/service.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"

--- a/vendor/github.com/docker/docker/registry/session.go
+++ b/vendor/github.com/docker/docker/registry/session.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -2,7 +2,7 @@
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.9
 github.com/Microsoft/go-winio v0.3.7
-github.com/Sirupsen/logrus v0.11.0
+github.com/sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

--- a/vendor/github.com/docker/docker/volume/drivers/adapter.go
+++ b/vendor/github.com/docker/docker/volume/drivers/adapter.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/volume"
 )
 

--- a/vendor/github.com/docker/docker/volume/local/local.go
+++ b/vendor/github.com/docker/docker/volume/local/local.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"

--- a/vendor/github.com/docker/docker/volume/store/db.go
+++ b/vendor/github.com/docker/docker/volume/store/db.go
@@ -3,7 +3,7 @@ package store
 import (
 	"encoding/json"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
 )

--- a/vendor/github.com/docker/docker/volume/store/restore.go
+++ b/vendor/github.com/docker/docker/volume/store/restore.go
@@ -3,7 +3,7 @@ package store
 import (
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/drivers"

--- a/vendor/github.com/docker/docker/volume/store/store.go
+++ b/vendor/github.com/docker/docker/volume/store/store.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/docker/volume"

--- a/vendor/github.com/docker/go-connections/proxy/tcp_proxy.go
+++ b/vendor/github.com/docker/go-connections/proxy/tcp_proxy.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // TCPProxy is a proxy for TCP connections. It implements the Proxy interface to

--- a/vendor/github.com/docker/go-connections/proxy/udp_proxy.go
+++ b/vendor/github.com/docker/go-connections/proxy/udp_proxy.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/vendor/github.com/docker/go-connections/sockets/unix_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/unix_socket.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/user"
 )
 

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -12,7 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Options represents the information needed to create client and server TLS configurations.

--- a/vendor/github.com/johntdyer/slackrus/README.md
+++ b/vendor/github.com/johntdyer/slackrus/README.md
@@ -1,7 +1,7 @@
 slackrus
 ========
 
-Slack hook for [Logrus](https://github.com/Sirupsen/logrus). 
+Slack hook for [Logrus](https://github.com/sirupsen/logrus).
 
 ## Use
 
@@ -9,7 +9,7 @@ Slack hook for [Logrus](https://github.com/Sirupsen/logrus).
 package main
 
 import (
-	logrus "github.com/Sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 	"github.com/johntdyer/slackrus"
 	"os"
 )

--- a/vendor/github.com/johntdyer/slackrus/example/example.go
+++ b/vendor/github.com/johntdyer/slackrus/example/example.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	logrus "github.com/Sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 	"github.com/johntdyer/slackrus"
 	"os"
 )

--- a/vendor/github.com/johntdyer/slackrus/levels.go
+++ b/vendor/github.com/johntdyer/slackrus/levels.go
@@ -1,7 +1,7 @@
 package slackrus
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Supported log levels

--- a/vendor/github.com/johntdyer/slackrus/slackrus.go
+++ b/vendor/github.com/johntdyer/slackrus/slackrus.go
@@ -2,7 +2,7 @@
 package slackrus
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/johntdyer/slack-go"
 )
 

--- a/vendor/github.com/opencontainers/runc/Godeps/Godeps.json
+++ b/vendor/github.com/opencontainers/runc/Godeps/Godeps.json
@@ -3,7 +3,7 @@
 	"GoVersion": "go1.5.3",
 	"Deps": [
 		{
-			"ImportPath": "github.com/Sirupsen/logrus",
+			"ImportPath": "github.com/sirupsen/logrus",
 			"Comment": "v0.7.3-2-g26709e2",
 			"Rev": "26709e2714106fb8ad40b773b711ebce25b78914"
 		},

--- a/vendor/github.com/opencontainers/runc/events.go
+++ b/vendor/github.com/opencontainers/runc/events.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/urfave/cli"

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/stats_util_test.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/stats_util_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Rlimit struct {

--- a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"

--- a/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"

--- a/vendor/github.com/opencontainers/runc/libcontainer/integration/init_test.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/integration/init_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"

--- a/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/utils"
 )

--- a/vendor/github.com/opencontainers/runc/main.go
+++ b/vendor/github.com/opencontainers/runc/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )

--- a/vendor/github.com/opencontainers/runc/restore.go
+++ b/vendor/github.com/opencontainers/runc/restore.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/specconv"

--- a/vendor/github.com/opencontainers/runc/signals.go
+++ b/vendor/github.com/opencontainers/runc/signals.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/utils"

--- a/vendor/github.com/opencontainers/runc/utils.go
+++ b/vendor/github.com/opencontainers/runc/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )

--- a/vendor/github.com/opencontainers/runc/utils_linux.go
+++ b/vendor/github.com/opencontainers/runc/utils_linux.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"


### PR DESCRIPTION
When I built Pumba locally, I got an error which like bellow:
`/var/root/go/src/github.com/johntdyer/slackrus/levels.go:4:2: case-insensitive import collision: "github.com/sirupsen/logrus" and "github.com/Sirupsen/logrus"`

I did some research and find https://github.com/sirupsen/logrus/issues/543. After batching replacement "Sirupsen/logrus" to "sirupsen/logrus" in your project,  I can build successful. Hope to help.