### PR TITLE
Fix for goLang builder image issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 # ----- Go Builder Image ------
 #
-FROM golang:alpine
+FROM golang:1.7.1-alpine
 
 # github-release - Github Release and upload artifacts
 # go-junit-report - convert Go test into junit.xml format


### PR DESCRIPTION
Resolves the issue of :
Error parsing reference: "golang:1.10-alpine AS builder" is not a valid repository/tag: invalid reference format