### PR TITLE
Update interface regexp

### DIFF
--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -66,7 +66,7 @@ func NewCorruptCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -75,7 +75,7 @@ func NewDelayCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -66,7 +66,7 @@ func NewDuplicateCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -66,7 +66,7 @@ func NewLossCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -70,7 +70,7 @@ func NewLossGECommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -72,7 +72,7 @@ func NewLossStateCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -82,7 +82,7 @@ func NewRateCommand(client container.Client,
 		return nil, err
 	}
 	// protect from Command Injection, using Regexp
-	reInterface := regexp.MustCompile("[a-zA-Z]+[0-9]{0,2}")
+	reInterface := regexp.MustCompile("[a-zA-Z][a-zA-Z0-9_-]*")
 	validIface := reInterface.FindString(iface)
 	if iface != validIface {
 		err = fmt.Errorf("bad network interface name: must match '%s'", reInterface.String())


### PR DESCRIPTION
There are interface names which contains under score("_"), for example `br-a9ecc29db51e`.