### PR TITLE
fix(openshift): pumba not in path, debug not an option

### DIFF
--- a/deploy/pumba_openshift.yml
+++ b/deploy/pumba_openshift.yml
@@ -13,8 +13,8 @@ spec:
       - image: gaiaadm/pumba:master
         imagePullPolicy: Always
         name: pumba
-        command: ["pumba"] 
-        args: ["--random", "--debug", "--interval", "30s", "kill", "--signal", "SIGKILL", "re2:.*hello.*"]
+        command: ["/pumba"] 
+        args: ["--random", "--interval", "30s", "kill", "--signal", "SIGKILL", "re2:.*hello.*"]
         securityContext:
           runAsUser: 0
         volumeMounts:


### PR DESCRIPTION
Creating a daemonset from this sample, containers won't start, as pumba isn't found in `PATH`.
Fixing that first error, then pumba crashes while starting, as `debug` doesn't seem to be a recognized option.