### PR TITLE
Add support for specifying target networks (CIDR notation) #126

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ cd pumba
 Now create a new Pumba Docker image.
 
 ```sh
-docker build -t pumba -f Dockerfile .
+docker build -t pumba -f docker/Dockerfile .
 ```
 
 ## License

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -297,7 +297,7 @@ func initializeCLICommands() []cli.Command {
 				},
 				cli.StringSliceFlag{
 					Name:  "target, t",
-					Usage: "target IP filter; supports multiple IPs",
+					Usage: "target IP filter; supports multiple IPs; supports CIDR notation",
 				},
 				cli.StringFlag{
 					Name:  "tc-image",

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,7 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/engine v0.0.0-20190206233949-eb137ff1765f h1:syROiDcQNWAcDNPfq3dkPdnMYeomRmIGR1sGsYKLGN8=
+github.com/docker/engine v0.0.0-20190206233949-eb137ff1765f h1:mhfXDTAewKkr4i4/+jprujJYs+DhP3NimGLiELJc0JQ=
 github.com/docker/engine v0.0.0-20190206233949-eb137ff1765f/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -23,7 +23,7 @@ type CorruptCommand struct {
 	names       []string
 	pattern     string
 	iface       string
-	ips         []net.IP
+	ips         []*net.IPNet
 	duration    time.Duration
 	percent     float64
 	correlation float64
@@ -74,9 +74,9 @@ func NewCorruptCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -28,7 +28,7 @@ type DelayCommand struct {
 	names        []string
 	pattern      string
 	iface        string
-	ips          []net.IP
+	ips          []*net.IPNet
 	duration     time.Duration
 	time         int
 	jitter       int
@@ -83,9 +83,9 @@ func NewDelayCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alexei-led/pumba/pkg/chaos"
 	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/alexei-led/pumba/pkg/util"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -57,7 +58,7 @@ func TestNewDelayCommand(t *testing.T) {
 				names:        []string{"n1", "n2"},
 				pattern:      "re2:test",
 				iface:        "testIface",
-				ips:          []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8")},
+				ips:          []*net.IPNet{util.ParseCIDR("1.2.3.4"), util.ParseCIDR("5.6.7.8")},
 				duration:     30 * time.Second,
 				time:         10,
 				jitter:       2,
@@ -196,7 +197,7 @@ func TestDelayCommand_Run(t *testing.T) {
 		names        []string
 		pattern      string
 		iface        string
-		ips          []net.IP
+		ips          []*net.IPNet
 		duration     time.Duration
 		time         int
 		jitter       int
@@ -224,7 +225,7 @@ func TestDelayCommand_Run(t *testing.T) {
 			fields: fields{
 				names:        []string{"c1"},
 				iface:        "eth0",
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     10 * time.Microsecond,
 				time:         2,
 				jitter:       1,
@@ -239,7 +240,7 @@ func TestDelayCommand_Run(t *testing.T) {
 			fields: fields{
 				names:        []string{"c1", "c2", "c3"},
 				iface:        "eth0",
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     10 * time.Microsecond,
 				time:         2,
 				jitter:       1,
@@ -254,7 +255,7 @@ func TestDelayCommand_Run(t *testing.T) {
 			fields: fields{
 				names:        []string{"c1", "c2", "c3"},
 				iface:        "eth0",
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     10 * time.Microsecond,
 				time:         2,
 				jitter:       1,
@@ -284,7 +285,7 @@ func TestDelayCommand_Run(t *testing.T) {
 			fields: fields{
 				names:        []string{"c1", "c2", "c3"},
 				iface:        "eth0",
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     10 * time.Microsecond,
 				time:         2,
 				jitter:       1,

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -101,6 +101,16 @@ func TestNewDelayCommand(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid CIDR IP address",
+			args: args{
+				intervalStr: "1m",
+				durationStr: "30s",
+				iface:       "eth0",
+				ipsList:     []string{"1.2.3.4/3.4.5.6..."},
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid IP address",
 			args: args{
 				intervalStr: "1m",
@@ -220,6 +230,21 @@ func TestDelayCommand_Run(t *testing.T) {
 		wantErr  bool
 		errs     wantErrors
 	}{
+		{
+			name: "delay with CIDR IP",
+			fields: fields{
+				names:        []string{"c1"},
+				iface:        "eth0",
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.0/24")},
+				duration:     10 * time.Microsecond,
+				time:         2,
+				jitter:       1,
+				correlation:  10.0,
+				distribution: "normal",
+			},
+			expected: container.CreateTestContainers(1),
+			cmd:      []string{"delay", "2ms", "1ms", "10.00", "distribution", "normal"},
+		},
 		{
 			name: "delay single container",
 			fields: fields{

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -23,7 +23,7 @@ type DuplicateCommand struct {
 	names       []string
 	pattern     string
 	iface       string
-	ips         []net.IP
+	ips         []*net.IPNet
 	duration    time.Duration
 	percent     float64
 	correlation float64
@@ -74,9 +74,9 @@ func NewDuplicateCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -23,7 +23,7 @@ type LossCommand struct {
 	names       []string
 	pattern     string
 	iface       string
-	ips         []net.IP
+	ips         []*net.IPNet
 	duration    time.Duration
 	percent     float64
 	correlation float64
@@ -74,9 +74,9 @@ func NewLossCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -23,7 +23,7 @@ type LossGECommand struct {
 	names    []string
 	pattern  string
 	iface    string
-	ips      []net.IP
+	ips      []*net.IPNet
 	duration time.Duration
 	pg       float64
 	pb       float64
@@ -78,9 +78,9 @@ func NewLossGECommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -23,7 +23,7 @@ type LossStateCommand struct {
 	names    []string
 	pattern  string
 	iface    string
-	ips      []net.IP
+	ips      []*net.IPNet
 	duration time.Duration
 	p13      float64
 	p31      float64
@@ -80,9 +80,9 @@ func NewLossStateCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/chaos/netem/netem.go
+++ b/pkg/chaos/netem/netem.go
@@ -10,7 +10,7 @@ import (
 )
 
 // run network emulation command, stop netem on timeout or abort
-func runNetem(ctx context.Context, client container.Client, container container.Container, netInterface string, cmd []string, ips []net.IP, duration time.Duration, tcimage string, pull bool, dryRun bool) error {
+func runNetem(ctx context.Context, client container.Client, container container.Container, netInterface string, cmd []string, ips []*net.IPNet, duration time.Duration, tcimage string, pull bool, dryRun bool) error {
 	log.WithFields(log.Fields{
 		"id":       container.ID(),
 		"name":     container.Name(),

--- a/pkg/chaos/netem/netem_test.go
+++ b/pkg/chaos/netem/netem_test.go
@@ -49,6 +49,20 @@ func Test_runNetem(t *testing.T) {
 			},
 		},
 		{
+			name: "netem with CIDR IP",
+			args: args{
+				container: *container.NewContainer(
+					container.ContainerDetailsResponse(container.AsMap("Name", "c1")),
+					container.ImageDetailsResponse(container.AsMap()),
+				),
+				netInterface: "testIface",
+				cmd:          []string{"test", "--test"},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.0.0/16")},
+				duration:     time.Microsecond * 10,
+				tcimage:      "test/image",
+			},
+		},
+		{
 			name: "netem with abort",
 			args: args{
 				container: *container.NewContainer(

--- a/pkg/chaos/netem/netem_test.go
+++ b/pkg/chaos/netem/netem_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/alexei-led/pumba/pkg/util"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -20,7 +21,7 @@ func Test_runNetem(t *testing.T) {
 		container    container.Container
 		netInterface string
 		cmd          []string
-		ips          []net.IP
+		ips          []*net.IPNet
 		duration     time.Duration
 		tcimage      string
 		pull         bool
@@ -42,7 +43,7 @@ func Test_runNetem(t *testing.T) {
 				),
 				netInterface: "testIface",
 				cmd:          []string{"test", "--test"},
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     time.Microsecond * 10,
 				tcimage:      "test/image",
 			},
@@ -56,7 +57,7 @@ func Test_runNetem(t *testing.T) {
 				),
 				netInterface: "testIface",
 				cmd:          []string{"test", "--test"},
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     time.Microsecond * 10,
 				tcimage:      "test/image",
 			},
@@ -71,7 +72,7 @@ func Test_runNetem(t *testing.T) {
 				),
 				netInterface: "testIface",
 				cmd:          []string{"test", "--test"},
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     time.Microsecond * 10,
 				tcimage:      "test/image",
 			},
@@ -87,7 +88,7 @@ func Test_runNetem(t *testing.T) {
 				),
 				netInterface: "testIface",
 				cmd:          []string{"test", "--test"},
-				ips:          []net.IP{net.ParseIP("10.10.10.10")},
+				ips:          []*net.IPNet{util.ParseCIDR("10.10.10.10")},
 				duration:     time.Microsecond * 10,
 				tcimage:      "test/image",
 			},

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -35,7 +35,7 @@ type RateCommand struct {
 	names          []string
 	pattern        string
 	iface          string
-	ips            []net.IP
+	ips            []*net.IPNet
 	duration       time.Duration
 	rate           string
 	packetOverhead int
@@ -90,9 +90,9 @@ func NewRateCommand(client container.Client,
 		return nil, err
 	}
 	// validate ips
-	var ips []net.IP
+	var ips []*net.IPNet
 	for _, str := range ipsList {
-		ip := net.ParseIP(str)
+		ip := util.ParseCIDR(str)
 		if ip == nil {
 			err = fmt.Errorf("bad target: '%s' is not a valid IP", str)
 			return nil, err

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -36,8 +36,8 @@ type Client interface {
 	StopContainer(context.Context, Container, int, bool) error
 	KillContainer(context.Context, Container, string, bool) error
 	RemoveContainer(context.Context, Container, bool, bool, bool, bool) error
-	NetemContainer(context.Context, Container, string, []string, []net.IP, time.Duration, string, bool, bool) error
-	StopNetemContainer(context.Context, Container, string, []net.IP, string, bool, bool) error
+	NetemContainer(context.Context, Container, string, []string, []*net.IPNet, time.Duration, string, bool, bool) error
+	StopNetemContainer(context.Context, Container, string, []*net.IPNet, string, bool, bool) error
 	PauseContainer(context.Context, Container, bool) error
 	UnpauseContainer(context.Context, Container, bool) error
 	StartContainer(context.Context, Container, bool) error
@@ -223,7 +223,7 @@ func (client dockerClient) RemoveContainer(ctx context.Context, c Container, for
 	return nil
 }
 
-func (client dockerClient) NetemContainer(ctx context.Context, c Container, netInterface string, netemCmd []string, ips []net.IP, duration time.Duration, tcimage string, pull bool, dryrun bool) error {
+func (client dockerClient) NetemContainer(ctx context.Context, c Container, netInterface string, netemCmd []string, ips []*net.IPNet, duration time.Duration, tcimage string, pull bool, dryrun bool) error {
 	prefix := ""
 	if dryrun {
 		prefix = dryRunPrefix
@@ -242,7 +242,7 @@ func (client dockerClient) NetemContainer(ctx context.Context, c Container, netI
 	return err
 }
 
-func (client dockerClient) StopNetemContainer(ctx context.Context, c Container, netInterface string, ip []net.IP, tcimage string, pull bool, dryrun bool) error {
+func (client dockerClient) StopNetemContainer(ctx context.Context, c Container, netInterface string, ip []*net.IPNet, tcimage string, pull bool, dryrun bool) error {
 	log.WithFields(log.Fields{
 		"name":     c.Name(),
 		"id":       c.ID(),
@@ -302,7 +302,7 @@ func (client dockerClient) startNetemContainer(ctx context.Context, c Container,
 	return nil
 }
 
-func (client dockerClient) stopNetemContainer(ctx context.Context, c Container, netInterface string, ips []net.IP, tcimage string, pull bool, dryrun bool) error {
+func (client dockerClient) stopNetemContainer(ctx context.Context, c Container, netInterface string, ips []*net.IPNet, tcimage string, pull bool, dryrun bool) error {
 	log.WithFields(log.Fields{
 		"name":    c.Name(),
 		"id":      c.ID(),
@@ -366,7 +366,7 @@ func (client dockerClient) stopNetemContainer(ctx context.Context, c Container, 
 }
 
 func (client dockerClient) startNetemContainerIPFilter(ctx context.Context, c Container, netInterface string, netemCmd []string,
-	ips []net.IP, tcimage string, pull bool, dryrun bool) error {
+	ips []*net.IPNet, tcimage string, pull bool, dryrun bool) error {
 	log.WithFields(log.Fields{
 		"name":    c.Name(),
 		"id":      c.ID(),

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/alexei-led/pumba/mocks"
+	"github.com/alexei-led/pumba/pkg/util"
 )
 
 func NewMockEngine() *mocks.APIClient {
@@ -467,13 +468,13 @@ func TestNetemContainerIPFilter_Success(t *testing.T) {
 	engineClient.On("ContainerExecInspect", ctx, "cmd4").Return(types.ContainerExecInspect{}, nil)
 
 	config5 := types.ExecConfig{Cmd: []string{"tc", "filter", "add", "dev", "eth0", "protocol", "ip",
-		"parent", "1:0", "prio", "1", "u32", "match", "ip", "dst", "10.10.0.1", "flowid", "1:3"}, Privileged: true}
+		"parent", "1:0", "prio", "1", "u32", "match", "ip", "dst", "10.10.0.1/32", "flowid", "1:3"}, Privileged: true}
 	engineClient.On("ContainerExecCreate", ctx, "abc123", config5).Return(types.IDResponse{ID: "cmd5"}, nil)
 	engineClient.On("ContainerExecStart", ctx, "cmd5", types.ExecStartCheck{}).Return(nil)
 	engineClient.On("ContainerExecInspect", ctx, "cmd5").Return(types.ContainerExecInspect{}, nil)
 
 	client := dockerClient{containerAPI: engineClient}
-	err := client.NetemContainer(context.TODO(), c, "eth0", []string{"delay", "500ms"}, []net.IP{net.ParseIP("10.10.0.1")}, 1*time.Millisecond, "", false, false)
+	err := client.NetemContainer(context.TODO(), c, "eth0", []string{"delay", "500ms"}, []*net.IPNet{util.ParseCIDR("10.10.0.1")}, 1*time.Millisecond, "", false, false)
 
 	assert.NoError(t, err)
 	engineClient.AssertExpectations(t)

--- a/pkg/container/mock_Client.go
+++ b/pkg/container/mock_Client.go
@@ -73,11 +73,11 @@ func (_m *MockClient) ListContainers(_a0 context.Context, _a1 Filter) ([]Contain
 }
 
 // NetemContainer provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8
-func (_m *MockClient) NetemContainer(_a0 context.Context, _a1 Container, _a2 string, _a3 []string, _a4 []net.IP, _a5 time.Duration, _a6 string, _a7 bool, _a8 bool) error {
+func (_m *MockClient) NetemContainer(_a0 context.Context, _a1 Container, _a2 string, _a3 []string, _a4 []*net.IPNet, _a5 time.Duration, _a6 string, _a7 bool, _a8 bool) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, Container, string, []string, []net.IP, time.Duration, string, bool, bool) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, Container, string, []string, []*net.IPNet, time.Duration, string, bool, bool) error); ok {
 		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 	} else {
 		r0 = ret.Error(0)
@@ -143,11 +143,11 @@ func (_m *MockClient) StopContainer(_a0 context.Context, _a1 Container, _a2 int,
 }
 
 // StopNetemContainer provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6
-func (_m *MockClient) StopNetemContainer(_a0 context.Context, _a1 Container, _a2 string, _a3 []net.IP, _a4 string, _a5 bool, _a6 bool) error {
+func (_m *MockClient) StopNetemContainer(_a0 context.Context, _a1 Container, _a2 string, _a3 []*net.IPNet, _a4 string, _a5 bool, _a6 bool) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, Container, string, []net.IP, string, bool, bool) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, Container, string, []*net.IPNet, string, bool, bool) error); ok {
 		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		r0 = ret.Error(0)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -70,7 +70,7 @@ func ParseCIDR(ip string) *net.IPNet {
 
 	_, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
-		// log.Fatal(err)
+		log.Error(err)
 		return nil
 	}
 	return ipNet

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,8 @@ package util
 import (
 	"errors"
 	"time"
+	"strings"
+	"net"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -52,4 +54,24 @@ func GetDurationValue(durationStr string, interval time.Duration) (time.Duration
 		return 0, errors.New("duration must be shorter than interval")
 	}
 	return duration, nil
+}
+
+// CIDRNotation Ensure IP string is in CIDR notation
+func CIDRNotation(ip string) string {
+	if !strings.Contains(ip, "/") {
+		return ip + "/32"
+	}
+	return ip
+}
+
+// ParseCIDR Parse IP string to IPNet
+func ParseCIDR(ip string) *net.IPNet {
+	cidr := CIDRNotation(ip)
+
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		// log.Fatal(err)
+		return nil
+	}
+	return ipNet
 }


### PR DESCRIPTION
This PR implements support for specifying networks (in CIDR notation) to netem commands. Both IPs and networks can be specified as target. Fixes #126.

e.g.
```
docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock pumba netem --interface eth0 --tc-image gaiadocker/iproute2 --duration 1m --target 172.217.12.0/24 loss --percent 50 tryme
```

With these changes, pumba has all tc commands using CIDR notation. If an user supplies a single IP address, pumba will translate it to CIDR (append /32) and pass it to tc.