### PR TITLE
pumba docker and netem commands fail with zero matching containers

### DIFF
--- a/pkg/chaos/docker/kill.go
+++ b/pkg/chaos/docker/kill.go
@@ -89,8 +89,9 @@ func (k *KillCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers to kill")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", k.names, k.pattern, k.labels)
+		log.WithError(err).Error("no containers to kill")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/docker/kill_test.go
+++ b/pkg/chaos/docker/kill_test.go
@@ -92,6 +92,7 @@ func TestKillCommand_Run(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
+			wantErr: true,
 		},
 		{
 			name: "error listing containers",

--- a/pkg/chaos/docker/pause.go
+++ b/pkg/chaos/docker/pause.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/alexei-led/pumba/pkg/chaos"
@@ -52,8 +53,9 @@ func (p *PauseCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers to stop")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", p.names, p.pattern, p.labels)
+		log.WithError(err).Error("no containers to pause")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/docker/pause_test.go
+++ b/pkg/chaos/docker/pause_test.go
@@ -124,6 +124,7 @@ func TestPauseCommand_Run(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
+			wantErr: true,
 		},
 		{
 			name: "error listing containers",

--- a/pkg/chaos/docker/remove.go
+++ b/pkg/chaos/docker/remove.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alexei-led/pumba/pkg/chaos"
 	"github.com/alexei-led/pumba/pkg/container"
@@ -42,8 +43,9 @@ func (r *RemoveCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers to remove")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", r.names, r.pattern, r.labels)
+		log.WithError(err).Error("no containers to remove")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/docker/remove_test.go
+++ b/pkg/chaos/docker/remove_test.go
@@ -83,6 +83,7 @@ func TestRemoveCommand_Run(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
+			wantErr: true,
 		},
 		{
 			name: "error listing containers",

--- a/pkg/chaos/docker/stop.go
+++ b/pkg/chaos/docker/stop.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/alexei-led/pumba/pkg/chaos"
@@ -63,8 +64,9 @@ func (s *StopCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers to stop")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", s.names, s.pattern, s.labels)
+		log.WithError(err).Error("no containers to stop")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/docker/stop_test.go
+++ b/pkg/chaos/docker/stop_test.go
@@ -178,6 +178,7 @@ func TestStopCommand_Run(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 			},
+			wantErr: true,
 		},
 		{
 			name: "error listing containers",

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -128,8 +128,9 @@ func (n *CorruptCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem corrupt")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -149,8 +149,9 @@ func (n *DelayCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem delay")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -297,6 +297,7 @@ func TestDelayCommand_Run(t *testing.T) {
 			fields: fields{
 				names: []string{"c1"},
 			},
+			wantErr: true,
 		},
 		{
 			name: "error listing containers",

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -128,8 +128,9 @@ func (n *DuplicateCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem duplicate")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -128,8 +128,9 @@ func (n *LossCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem loss")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -148,8 +148,9 @@ func (n *LossGECommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem loss_ge")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -158,8 +158,9 @@ func (n *LossStateCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem loss_state")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -154,8 +154,9 @@ func (n *RateCommand) Run(ctx context.Context, random bool) error {
 		return err
 	}
 	if len(containers) == 0 {
-		log.Warning("no containers found")
-		return nil
+		err := fmt.Errorf("no containers matching names = %s, pattern = %s, labels = %s", n.names, n.pattern, n.labels)
+		log.WithError(err).Error("no containers to netem rate")
+		return err
 	}
 
 	// select single random container from matching container and replace list with selected item

--- a/tests/netem.bats
+++ b/tests/netem.bats
@@ -18,8 +18,8 @@
 
 @test "Netem Delay 200ms" {
   run pumba netem --duration 200ms delay --time 100 test
-  [ $status -eq 0 ]
-  [[ $output =~ "no containers found" ]]
+  [ $status -eq 1 ]
+  [[ $output =~ "no containers" ]]
 }
 
 @test "Netem Delay 200ms External Image" {


### PR DESCRIPTION
Docker kill, pause, remove and stop commands and netem commands corrupt, delay, duplicate, loss, loss_state, loss_ge and rate now raise errors when they find no containers to harass. Consequently, the `pumba` command will `exit 1`. This makes it easier to handle error/unexpected cases Pumba programmatically. I think it is quite rare that Pumba is executed "speculatively" in a way that it would be an acceptable outcome that zero containers are targeted.

Fixes #145.