### PR TITLE
Update docker engine to allow cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/docker/docker v1.13.1 => github.com/docker/engine v1.4.2-0.20180718150940-a3ef7e9a9bda
+replace github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.20190717161051-705d9623b7c1+incompatible
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/engine v1.4.2-0.20180718150940-a3ef7e9a9bda h1:sKiesnlbd+xh7NGrFF1hDtMS4qq1nW3wl9v+lZag79s=
 github.com/docker/engine v1.4.2-0.20180718150940-a3ef7e9a9bda/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
+github.com/docker/engine v17.12.0-ce-rc1.0.20190717161051-705d9623b7c1+incompatible h1:4Pnn+RsurVEiBbmqlRtzh77HLMiP4NaaqRHOOK4aPj8=
+github.com/docker/engine v17.12.0-ce-rc1.0.20190717161051-705d9623b7c1+incompatible/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=

--- a/mocks/APIClient.go
+++ b/mocks/APIClient.go
@@ -40,12 +40,12 @@ type APIClient struct {
 }
 
 // BuildCachePrune provides a mock function with given fields: ctx
-func (_m *APIClient) BuildCachePrune(ctx context.Context) (*types.BuildCachePruneReport, error) {
-	ret := _m.Called(ctx)
+func (_m *APIClient) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
+	ret := _m.Called(ctx, opts)
 
 	var r0 *types.BuildCachePruneReport
-	if rf, ok := ret.Get(0).(func(context.Context) *types.BuildCachePruneReport); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, types.BuildCachePruneOptions) *types.BuildCachePruneReport); ok {
+		r0 = rf(ctx, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.BuildCachePruneReport)

--- a/mocks/ImageAPIClient.go
+++ b/mocks/ImageAPIClient.go
@@ -23,12 +23,12 @@ type ImageAPIClient struct {
 }
 
 // BuildCachePrune provides a mock function with given fields: ctx
-func (_m *ImageAPIClient) BuildCachePrune(ctx context.Context) (*types.BuildCachePruneReport, error) {
-	ret := _m.Called(ctx)
+func (_m *ImageAPIClient) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
+	ret := _m.Called(ctx, opts)
 
 	var r0 *types.BuildCachePruneReport
-	if rf, ok := ret.Get(0).(func(context.Context) *types.BuildCachePruneReport); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, types.BuildCachePruneOptions) *types.BuildCachePruneReport); ok {
+		r0 = rf(ctx, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.BuildCachePruneReport)

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -64,7 +64,7 @@ func NewClient(dockerHost string, tlsConfig *tls.Config) (Client, error) {
 		return nil, err
 	}
 
-	apiClient, err := dockerapi.NewClient(dockerHost, "", httpClient, nil)
+	apiClient, err := dockerapi.NewClientWithOpts(dockerapi.WithHost(dockerHost), dockerapi.WithHTTPClient(httpClient), dockerapi.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This MR updates the docker engine so we can use `NewClientWithOpts` and version negotiation so that cleaning up the tc containers works. Previously, we were using the default version of the docker API, 1.23, where cleanup with `AutoRemove` as a Docker Host Config is overridden to `false` by the Docker engine and does not actually clean anything up. 

With this MR we get version negotiation so that it will select the appropriate version of the Docker API to match the Docker version of where Pumba is being ran so there will be both explicit compatibility and the ability for the containers to be cleaned up so long as Docker is > 1.13.0.