### PR TITLE
Replace `go get` with `go install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,19 +66,19 @@ release: clean ; $(info $(M) building binaries for multiple os/arch...) @ ## Bui
 setup-tools: setup-golint setup-golangci-lint setup-gocov setup-gocov-xml setup-go2xunit
 
 setup-golint:
-	$(GO) get golang.org/x/lint/golint
+	$(GO) install golang.org/x/lint/golint
 setup-golangci-lint:
-	$(GO) get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
 setup-gocov:
-	$(GO) get github.com/axw/gocov/...
+	$(GO) install github.com/axw/gocov/...
 setup-gocov-xml:
-	$(GO) get github.com/AlekSi/gocov-xml
+	$(GO) install github.com/AlekSi/gocov-xml
 setup-go2xunit:
-	$(GO) get github.com/tebeka/go2xunit
+	$(GO) install github.com/tebeka/go2xunit
 setup-mockery:
-	$(GO) get github.com/vektra/mockery/v2/
+	$(GO) install github.com/vektra/mockery/v2/
 setup-ghr:
-	$(GO) get github.com/tcnksm/ghr
+	$(GO) install github.com/tcnksm/ghr
 
 GOLINT=golint
 GOCOV=gocov


### PR DESCRIPTION
Fixes #198 .
```
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```