### PR TITLE
ci: added support darwin arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ release: clean ; $(info $(M) building binaries for multiple os/arch...) @ ## Bui
 	$(foreach GOOS, $(PLATFORMS),\
 		$(foreach GOARCH, $(ARCHITECTURES), \
 			$(shell \
-				if [ "$(GOARCH)" = "arm64" ] && [ "$(GOOS)" != "linux" ]; then exit 0; fi; \
 				GOPROXY=$(GOPROXY) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 				$(GO) build \
 				-tags release \


### PR DESCRIPTION
This PR adds support for Darwin arm64. The makefile has been updated to add support for Darwin arm64

Closes #201 