### PR TITLE
Fixed issue203

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,7 +306,7 @@ func initializeCLICommands() []cli.Command {
 					Name:  "tc-image",
 					Usage: "Docker image with tc (iproute2 package); try 'gaiadocker/iproute2'",
 				},
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "pull-image",
 					Usage: "try to pull tc-image",
 				},

--- a/pkg/chaos/netem/cmd/delay.go
+++ b/pkg/chaos/netem/cmd/delay.go
@@ -76,7 +76,7 @@ func (cmd *delayContext) delay(c *cli.Context) error {
 	// get traffic control image from parent `netem` command
 	image := c.Parent().String("tc-image")
 	// get pull tc image flag
-	pull := c.Parent().BoolT("pull-image")
+	pull := c.Parent().Bool("pull-image")
 	// get limit for number of containers to netem
 	limit := c.Parent().Int("limit")
 


### PR DESCRIPTION
I was testing the code and BoolT flag doesn't work with _--pull-image arg in the **pumba netem** command, for this reason I changed the Flag **pull-image** from **BoolTFlag** to **BoolFlag**. I'm currently using this changes in my work environment and works perfectly.

it's very important that when you not use this flag  the **pull value** will be **false**  to avoid rate limits from docker and only pull the image that use "tc-image" when it will necesary.

Pumba is amazing !!!  