### PR TITLE
Replace deprecated ioutil with other functions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -241,7 +240,7 @@ func tlsConfig(c *cli.Context) (*tls.Config, error) {
 		if caCertFlag != "" {
 			var caCert []byte
 			if strings.HasPrefix(caCertFlag, "/") {
-				caCert, err = ioutil.ReadFile(caCertFlag)
+				caCert, err = os.ReadFile(caCertFlag)
 				if err != nil {
 					return nil, errors.Wrap(err, "unable to read CA certificate")
 				}

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"time"
@@ -167,7 +166,7 @@ func (client dockerClient) ExecContainer(ctx context.Context, c *Container, comm
 			return errors.Wrap(err, "exec start failed")
 		}
 
-		output, err := ioutil.ReadAll(attachRes.Reader)
+		output, err := io.ReadAll(attachRes.Reader)
 		if err != nil {
 			return errors.Wrap(err, "reading output from exec reader failed")
 		}


### PR DESCRIPTION
Fixes https://github.com/alexei-led/pumba/issues/213

```
ioutilDeprecated: ioutil.ReadAll is deprecated, use io.ReadAll instead

ioutil.ReadFile is deprecated, use os.ReadFile instead
```