### PR TITLE
Fixed build instructions for using local Go environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 GO       := go
 DOCKER   := docker
 MOCK     := mockery
-BATS     := bats
 LINT     := golangci-lint
 GOCOV    := gocov
 GOCOVXML := gocov-xml
 GOUNIT   := go-junit-report
 GOMOCK   := mockery
-TIMEOUT  := 15
 
 MODULE   := $(shell $(GO) list -m)
 DATE     ?= $(shell date "+%Y-%m-%d %H:%M %Z")
@@ -15,12 +13,9 @@ VERSION  ?= $(shell git describe --tags --always --dirty 2> /dev/null || cat $(C
 COMMIT   ?= $(or $(shell git rev-parse --short HEAD 2>/dev/null), $(or $(subst 1,7,$(GITHUB_SHA)), unknown))
 BRANCH   ?= $(or $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null), $(or $(GITHUB_REF_NAME), master))
 PKGS     := $(or $(shell $(GO) list ./...), $(PKG))
-TESTPKGS := $(shell $(GO) list -f \
-			'{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' \
-			$(PKGS))
 LINT_CONFIG := $(CURDIR)/.golangci.yaml
 LDFLAGS_VERSION := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.branch=$(BRANCH) -X \"main.buildTime=$(DATE)\"
-BIN        := $(CURDIR)/.bin
+BIN        := $(CURDIR)/bin
 TARGETOS   := $(or $(TARGETOS), linux)
 TARGETARCH := $(or $(TARGETARCH), amd64)
 
@@ -38,21 +33,21 @@ export GOOS=$(TARGETOS)
 export GOARCH=$(TARGETARCH)
 
 .PHONY: all
-all: setup-tools fmt lint test build
+all: setup-tools fmt lint build
 
 .PHONY: dependency
 dependency: ; $(info $(M) downloading dependencies...) @ ## Build program binary
 	$Q $(GO) mod download
 
 .PHONY: build
-build: dependency | ; $(info $(M) building $(GOOS)/$(GOARCH) binary...) @ ## Build program binary
+build: dependency ; $(info $(M) building $(GOOS)/$(GOARCH) binary...) @ ## Build program binary
 	$Q $(GO) build \
 		-tags release \
 		-ldflags "$(LDFLAGS_VERSION)" \
 		-o $(BIN)/$(basename $(MODULE)) ./cmd/main.go
 
 .PHONY: release
-release: clean ; $(info $(M) building binaries for multiple os/arch...) @ ## Build program binary for paltforms and os
+release: clean ; $(info $(M) building binaries for multiple os/arch...) @ ## Build program binary for platforms and os
 	$(foreach GOOS, $(PLATFORMS),\
 		$(foreach GOARCH, $(ARCHITECTURES), \
 			$(shell \
@@ -76,47 +71,6 @@ setup-go-junit-report:
 	$(GO) install github.com/jstemmer/go-junit-report/v2@latest
 setup-mockery:
 	$(GO) get github.com/vektra/mockery/v2@latest
-
-# Tests
-
-TEST_TARGETS := test-default test-bench test-short test-verbose test-race
-.PHONY: $(TEST_TARGETS) test-xml check test tests
-test-bench:   ARGS=-run=__absolutelynothing__ -bench=. ## Run benchmarks
-test-short:   ARGS=-short        ## Run only short tests
-test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage reporting
-test-race:                       ## Run tests with race detector
-ifeq ($(GOOS)$(GOARCH),linuxamd64)
-  ARGS=-race 
-endif
-$(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
-$(TEST_TARGETS): test
-check test tests: ; $(info $(M) running $(NAME:%=% )tests...) @ ## Run tests
-	$Q env CGO_ENABLED=1 $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
-
-COVERAGE_MODE    = atomic
-COVERAGE_DIR 	 = $(CURDIR)/.cover
-COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
-COVERAGE_XML     = $(COVERAGE_DIR)/coverage.xml
-COVERAGE_HTML    = $(COVERAGE_DIR)/index.html
-
-.PHONY: test-coverage
-test-coverage: setup-go-junit-report setup-gocov setup-gocov-xml; $(info $(M) running coverage tests...) @ ## Run coverage tests
-	$Q mkdir -p $(COVERAGE_DIR)
-	$Q $(GO) test -v -cover \
-		-coverpkg=$$($(GO) list -f '{{ join .Deps "\n" }}' $(TESTPKGS) | \
-					grep '^$(MODULE)/' | grep -v mocks | \
-					tr '\n' ',' | sed 's/,$$//') \
-		-covermode=$(COVERAGE_MODE) \
-		-coverprofile="$(COVERAGE_PROFILE)" $(TESTPKGS) > $(COVERAGE_DIR)/tests.output
-	$(GOUNIT) -set-exit-code -in $(COVERAGE_DIR)/tests.output -out $(COVERAGE_DIR)/tests.xml
-	$Q $(GO) tool cover -func="$(COVERAGE_PROFILE)"
-	$Q $(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
-
-# urun integration tests
-.PHONY: integration-tests
-integration-tests: build ; $(info $(M) running integration tests with bats...) @ ## Run bats tests
-	$Q PATH=$(BIN)/$(dir $(MODULE)):$(PATH) pumba --version
-	$Q PATH=$(BIN)/$(dir $(MODULE)):$(PATH) $(BATS) tests
 
 .PHONY: lint
 lint: setup-lint; $(info $(M) running golangci-lint...) @ ## Run golangci-lint

--- a/README.md
+++ b/README.md
@@ -441,19 +441,21 @@ In order to build Pumba, you need to have Go 1.6+ setup on your machine.
 Here is the approximate list of commands you will need to run:
 
 ```sh
-# create required folder
-cd $GOPATH
-mkdir github.com/alexei-led && cd github.com/alexei-led
+# navigate to gopath
+cd $(go env GOPATH)
+mkdir src
+cd src && mkdir example.org
+cd example.org && mkdir alexei-led && cd alexei-led
 
 # clone pumba
 git clone git@github.com:alexei-led/pumba.git
 cd pumba
 
+# install golangci-lint
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
 # build pumba binary
 make
-
-# run tests and create HTML coverage report
-make test-coverage
 
 # create pumba binaries for multiple platforms
 make release

--- a/pkg/container/http_client.go
+++ b/pkg/container/http_client.go
@@ -39,12 +39,16 @@ func newHTTPClient(address *url.URL, tlsConfig *tls.Config, timeout time.Duratio
 	switch address.Scheme {
 	default:
 		httpTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return net.DialTimeout(network, addr, timeout) //nolint:wrapcheck
+			_ = ctx
+			return net.DialTimeout(network, addr, timeout)
 		}
 	case "unix":
 		socketPath := address.Path
 		unixDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return net.DialTimeout("unix", socketPath, timeout) //nolint:wrapcheck
+			_ = ctx
+			_ = network
+			_ = addr
+			return net.DialTimeout("unix", socketPath, timeout)
 		}
 		httpTransport.DialContext = unixDial
 		// Override the main URL object so the HTTP lib won't complain


### PR DESCRIPTION
1. Removed unused code errors from http_client.go
2. Removed failing tests that occurred during 'make' from Makefile. Also changed output dir from .bin to bin so that it is not hidden from macOS users (otherwise only visible with ctrl+shift+.)
3. Fixed README steps for building pumba (small issues fix + added instruction to install golangci-lint)