### PR TITLE
docs: clarify --stressors flag usage syntax

### DIFF
--- a/pkg/chaos/stress/cmd/stress.go
+++ b/pkg/chaos/stress/cmd/stress.go
@@ -35,11 +35,11 @@ func NewStressCLICommand(ctx context.Context) *cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "stressors",
-				Usage: "stress-ng stressors; see https://kernel.ubuntu.com/~cking/stress-ng/",
+				Usage: `stress-ng stressors; use = sign to pass values, e.g. --stressors="--cpu 4 --timeout 60s"; see https://kernel.ubuntu.com/~cking/stress-ng/`,
 				Value: "--cpu 4 --timeout 60s",
 			},
 		},
-		Usage:       "stress test a specified containers",
+		Usage:       "stress test specified containers",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q)", chaos.Re2Prefix),
 		Description: "stress test target container(s)",
 		Action:      cmdContext.stress,


### PR DESCRIPTION
Closes #216

The `--stressors` flag requires `=` sign when passing values that start with dashes:

```bash
# ✅ Correct
pumba stress --stressors="--cpu 4 --timeout 60s" container

# ❌ Wrong (parsed as separate flags)
pumba stress --stressors "--cpu 4 --timeout 60s" container
```

This is a limitation of the CLI flag parser (urfave/cli) — values starting with `--` get parsed as new flags unless bound with `=`.

Updated the help text to document this clearly.