### PR TITLE
fix: graceful handling when container removed during netem/iptables

### DIFF
--- a/pkg/chaos/iptables/iptables.go
+++ b/pkg/chaos/iptables/iptables.go
@@ -114,14 +114,14 @@ func runIPTables(ctx context.Context, client container.Client, c *container.Cont
 		// use different context to stop iptables since parent context is canceled
 		err = client.StopIPTablesContainer(context.Background(), c, delCmdPrefix, cmdSuffix, srcIPs, dstIPs, sports, dports, image, pull, dryRun)
 		if err != nil {
-			return fmt.Errorf("failed to stop iptables container: %w", err)
+			logger.WithError(err).Warn("failed to stop iptables container (container may have been removed)")
 		}
 	case <-stopCtx.Done():
 		logger.Debug("stopping iptables command on timout")
 		// use parent context to stop iptables in container
 		err = client.StopIPTablesContainer(context.Background(), c, delCmdPrefix, cmdSuffix, srcIPs, dstIPs, sports, dports, image, pull, dryRun)
 		if err != nil {
-			return fmt.Errorf("failed to stop tables container: %w", err)
+			logger.WithError(err).Warn("failed to stop iptables container (container may have been removed)")
 		}
 	}
 	return nil

--- a/pkg/chaos/iptables/iptables_test.go
+++ b/pkg/chaos/iptables/iptables_test.go
@@ -112,7 +112,7 @@ func Test_runIPTables(t *testing.T) {
 				iptablesImage: "test/image",
 			},
 			errs:    errs{stopErr: true},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/chaos/netem/netem.go
+++ b/pkg/chaos/netem/netem.go
@@ -97,14 +97,16 @@ func runNetem(ctx context.Context, client container.Client, c *container.Contain
 		// use different context to stop netem since parent context is canceled
 		err = client.StopNetemContainer(context.Background(), c, netInterface, ips, sports, dports, tcimage, pull, dryRun)
 		if err != nil {
-			return fmt.Errorf("failed to stop netem container: %w", err)
+			// if container was killed/removed while netem was running, log warning and continue
+			logger.WithError(err).Warn("failed to stop netem container (container may have been removed)")
 		}
 	case <-stopCtx.Done():
 		logger.Debug("stopping netem command on timout")
 		// use parent context to stop netem in container
 		err = client.StopNetemContainer(context.Background(), c, netInterface, ips, sports, dports, tcimage, pull, dryRun)
 		if err != nil {
-			return fmt.Errorf("failed to stop netem container: %w", err)
+			// if container was killed/removed while netem was running, log warning and continue
+			logger.WithError(err).Warn("failed to stop netem container (container may have been removed)")
 		}
 	}
 	return nil

--- a/pkg/chaos/netem/netem_test.go
+++ b/pkg/chaos/netem/netem_test.go
@@ -96,7 +96,7 @@ func Test_runNetem(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "netem error in StopNetemContainer",
+			name: "netem warning on StopNetemContainer failure",
 			args: args{
 				container: &container.Container{
 					ContainerInfo: container.DetailsResponse(container.AsMap("Name", "c1")),
@@ -109,7 +109,7 @@ func Test_runNetem(t *testing.T) {
 				tcimage:      "test/image",
 			},
 			errs:    errs{stopErr: true},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #175

When a target container is killed/removed while pumba is running netem or iptables commands, the cleanup would fail with `No such container` and pumba would exit with a fatal error.

Now pumba logs a warning and continues running — the expected behavior for ephemeral containers (ECS, K8s, etc.).

**Changes:**
- `pkg/chaos/netem/netem.go` — warn instead of fatal on StopNetemContainer failure
- `pkg/chaos/iptables/iptables.go` — same for StopIPTablesContainer
- Updated tests to match new behavior