### PR TITLE
ci: migrate to native multi-arch builds and GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,22 +2,12 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
-      - main
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-    paths-ignore:
-      - 'docs/**'
-      - 'deploy/**'
-      - 'examples/**'
-      - 'test/**'
-      - '*.md'
-      - '*.yaml'
 
 jobs:
+  # Build and test Go binaries
   build:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,38 +16,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set Up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
           cache: true
           cache-dependency-path: go.sum
+
       - name: Run Lint and Test Coverage
-        shell: bash
         run: |
           make lint
           make test-coverage
+
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: ".cover/coverage.xml"
           token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Build Release Binaries
         env:
           GOPROXY: https://proxy.golang.org
           CGO_ENABLED: 0
-        run: |
-          make release
-      - name: Debug Directory Contents
-        run: |
-          echo "Current working directory:"
-          pwd
-          echo "Listing contents of .bin/ recursively:"
-          find .bin/ -type f -ls || echo "No files found in .bin/"
-          echo "Directory structure:"
-          ls -laR .bin/ || echo "Directory .bin/ is empty or does not exist"
-          echo "Testing glob expansion:"
-          ls .bin/* || echo "Glob .bin/* found no files"
+        run: make release
+
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -67,43 +50,16 @@ jobs:
           compression-level: 6
           include-hidden-files: true
 
-  create-release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    name: Create GitHub Release
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: pumba-binaries
-          path: ${{ github.workspace }}/.bin/
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          body: "Automated release for ${{ github.ref_name }}"
-          generateReleaseNotes: true
-          prerelease: true
-          artifacts: ${{ github.workspace }}/.bin/*
-          allowUpdates: false
-          commit: ${{ github.sha }}
-          draft: false
-          removeArtifacts: false
-          replacesArtifacts: true
-
-  push-docker:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    name: Push Docker Image
-    runs-on: ubuntu-latest
+  # Build Docker images natively per architecture (no QEMU)
+  docker-build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -112,35 +68,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get Tag Name
-        id: get_tag
-        run: echo "git_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: Get Short SHA
         id: short_sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Set Up Docker Buildx
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          driver: docker-container
-          platforms: linux/amd64,linux/arm64
-      - name: Set Up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-      - name: Login to Docker Registry
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_ACCOUNT }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Build Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKER_ORG }}/pumba
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
-      - name: Build and Push Docker Image
+
+      - name: Build and push by digest (GHCR)
+        id: build-ghcr
         uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile
@@ -149,11 +99,123 @@ jobs:
             BRANCH=${{ github.ref_name }}
             COMMIT=${{ steps.short_sha.outputs.sha }}
             SKIP_TESTS=true
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          provenance: false
+
+      - name: Build and push by digest (Docker Hub)
+        id: build-hub
+        uses: docker/build-push-action@v6
+        with:
+          file: docker/Dockerfile
+          context: .
+          build-args: |
+            BRANCH=${{ github.ref_name }}
+            COMMIT=${{ steps.short_sha.outputs.sha }}
+            SKIP_TESTS=true
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ secrets.DOCKER_ORG }}/pumba,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          provenance: false
+
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/ghcr /tmp/digests/hub
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          hub_digest="${{ steps.build-hub.outputs.digest }}"
+          touch "/tmp/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "/tmp/digests/hub/${hub_digest#sha256:}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.runner }}
+          path: /tmp/digests
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge multi-arch manifests
+  docker-merge:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_ACCOUNT }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Create and push manifest (GHCR)
+        working-directory: /tmp/digests/ghcr
+        run: |
+          printf 'ghcr.io/${{ github.repository }}@sha256:%s\n' * > /tmp/ghcr-sources.txt
+          docker buildx imagetools create \
+            -t "ghcr.io/${{ github.repository }}:${{ github.ref_name }}" \
+            -t "ghcr.io/${{ github.repository }}:latest" \
+            $(cat /tmp/ghcr-sources.txt)
+
+      - name: Create and push manifest (Docker Hub)
+        working-directory: /tmp/digests/hub
+        run: |
+          printf '${{ secrets.DOCKER_ORG }}/pumba@sha256:%s\n' * > /tmp/hub-sources.txt
+          docker buildx imagetools create \
+            -t "${{ secrets.DOCKER_ORG }}/pumba:${{ github.ref_name }}" \
+            -t "${{ secrets.DOCKER_ORG }}/pumba:latest" \
+            $(cat /tmp/hub-sources.txt)
+
+      - name: Inspect GHCR image
+        run: docker buildx imagetools inspect "ghcr.io/${{ github.repository }}:${{ github.ref_name }}"
+
+  # Create GitHub Release
+  create-release:
+    name: Create GitHub Release
+    needs: [build, docker-merge]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pumba-binaries
+          path: ${{ github.workspace }}/.bin/
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generateReleaseNotes: true
+          prerelease: false
+          artifacts: ${{ github.workspace }}/.bin/*
+          allowUpdates: false
+          commit: ${{ github.sha }}
+          draft: false


### PR DESCRIPTION
## Summary

Modernizes the release workflow:

### Native multi-arch builds (no QEMU)
- **amd64** builds on `ubuntu-24.04` (native)
- **arm64** builds on `ubuntu-24.04-arm` (native)
- Digest-based push + manifest merge (same pattern as [nsenter](https://github.com/alexei-led/nsenter))
- Faster and more reliable than QEMU emulation

### GitHub Container Registry
- Primary registry: `ghcr.io/alexei-led/pumba`
- Docker Hub: still pushed (deprecated, will be removed later)
- Uses `GITHUB_TOKEN` for GHCR auth (no extra secrets needed)

### Other improvements
- Releases marked as stable (`prerelease: false`)
- Cleaner workflow structure (build → docker-build → docker-merge → create-release)