### PR TITLE
fix: support comma-separated labels in --label flag (#171)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,7 +137,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "label",
-			Usage: "filter containers by labels, e.g '--label key=value' (multiple labels supported)",
+			Usage: "filter containers by labels, e.g. '--label key=value' (use '--label k1=v1 --label k2=v2' or '--label k1=v1,k2=v2' for multiple, AND logic)",
 		},
 		cli.BoolFlag{
 			Name:  "random, r",

--- a/pkg/chaos/command.go
+++ b/pkg/chaos/command.go
@@ -37,12 +37,27 @@ type GlobalParams struct {
 	SkipErrors bool
 }
 
+// splitLabels splits comma-separated label values into individual labels.
+// This supports both "--label k1=v1 --label k2=v2" and "--label k1=v1,k2=v2" syntax.
+func splitLabels(raw []string) []string {
+	var result []string
+	for _, l := range raw {
+		for _, part := range strings.Split(l, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				result = append(result, part)
+			}
+		}
+	}
+	return result
+}
+
 // ParseGlobalParams parse global parameters
 func ParseGlobalParams(c *cli.Context) (*GlobalParams, error) {
 	// get random flag
 	random := c.GlobalBool("random")
-	// get labels
-	labels := c.GlobalStringSlice("label")
+	// get labels; support both --label k=v --label k2=v2 and --label k=v,k2=v2
+	labels := splitLabels(c.GlobalStringSlice("label"))
 	// get dry-run mode
 	dryRun := c.GlobalBool("dry-run")
 	// get skip error flag

--- a/pkg/chaos/command_test.go
+++ b/pkg/chaos/command_test.go
@@ -32,3 +32,34 @@ func TestRe2PatternExtraction(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []string
+		want []string
+	}{
+		{"single label", []string{"app=web"}, []string{"app=web"}},
+		{"two separate flags", []string{"app=web", "env=prod"}, []string{"app=web", "env=prod"}},
+		{"comma-separated", []string{"app=web,env=prod"}, []string{"app=web", "env=prod"}},
+		{"mixed", []string{"app=web,env=prod", "tier=frontend"}, []string{"app=web", "env=prod", "tier=frontend"}},
+		{"with spaces", []string{"app=web, env=prod"}, []string{"app=web", "env=prod"}},
+		{"empty string", []string{""}, nil},
+		{"empty slice", []string{}, nil},
+		{"k8s labels", []string{"io.kubernetes.container.name=myapp,app.kubernetes.io/version=v2"}, []string{"io.kubernetes.container.name=myapp", "app.kubernetes.io/version=v2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitLabels(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitLabels() = %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("splitLabels()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Using `--label k1=v1,k2=v2` passed a single string `"k1=v1,k2=v2"` to the Docker API, which never matched any containers.

## Fix

Added `splitLabels()` that splits comma-separated values into individual labels. Now both syntaxes work:
- `--label k1=v1 --label k2=v2` (separate flags)
- `--label k1=v1,k2=v2` (comma-separated)

Labels use AND logic (all must match).

## Tests

8 test cases covering single, multiple, comma-separated, mixed, K8s labels, and edge cases.

Fixes #171

---
*🤖 Fix by Marvin • [alexei-led](https://github.com/alexei-led)*