### PR TITLE
fix: restore release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,6 +196,7 @@ jobs:
           generateReleaseNotes: true
           prerelease: false
           artifacts: ${{ github.workspace }}/.bin/*
-          allowUpdates: false
+          allowUpdates: true
+          artifactErrorsFailBuild: true
           commit: ${{ github.sha }}
           draft: false


### PR DESCRIPTION
Fixes #320

Root cause: the 1.1.3 release already existed when the release workflow reached ncipollo/release-action, so release creation failed with `already_exists` before uploading the built binaries.
Fix: allow the release workflow to update an existing release and fail explicitly if artifact upload fails.