### PR TITLE
fix: failing tests on 1.1.6

### DIFF
--- a/pkg/runtime/containerd/client_test.go
+++ b/pkg/runtime/containerd/client_test.go
@@ -1419,20 +1419,35 @@ func TestStressContainer_SidecarExitCodes(t *testing.T) { //nolint:paralleltest 
 			require.NoError(t, err)
 			assert.Contains(t, id, "pumba-stress-")
 
-			select {
-			case out := <-outCh:
-				if tc.wantErrMsg != "" {
-					t.Fatalf("expected error, got success: %s", out)
+			timer := time.NewTimer(5 * time.Second)
+			defer timer.Stop()
+			for outCh != nil || errCh != nil {
+				select {
+				case out, ok := <-outCh:
+					if !ok {
+						outCh = nil
+						continue
+					}
+					if tc.wantErrMsg != "" {
+						t.Fatalf("expected error, got success: %s", out)
+					}
+					assert.Equal(t, id, out)
+					return
+				case e, ok := <-errCh:
+					if !ok {
+						errCh = nil
+						continue
+					}
+					if tc.wantErrMsg == "" {
+						t.Fatalf("unexpected error: %v", e)
+					}
+					assert.Contains(t, e.Error(), tc.wantErrMsg)
+					return
+				case <-timer.C:
+					t.Fatal("timeout")
 				}
-				assert.Equal(t, id, out)
-			case e := <-errCh:
-				if tc.wantErrMsg == "" {
-					t.Fatalf("unexpected error: %v", e)
-				}
-				assert.Contains(t, e.Error(), tc.wantErrMsg)
-			case <-time.After(5 * time.Second):
-				t.Fatal("timeout")
 			}
+			t.Fatal("stress sidecar completed without output or error")
 		})
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-package util
+package util //nolint:revive // legacy package name is part of the public import path
 
 import (
 	"fmt"


### PR DESCRIPTION
Fixes #322

Root cause: the sidecar stress test selected between output and error channels without checking whether a channel was closed; on successful sidecar completion the closed error channel could be selected and read as a nil error.
Fix: make the test ignore closed channels and wait for an actual output/error value. Also suppress the legacy pkg/util revive package-name lint warning so the configured lint command passes without renaming a public import path.