### PR TITLE
feat: support multiple RE2 regex patterns for container matching

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -61,7 +61,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 			},
 			Usage:       "emulate the properties of wide area networks",
-			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", re2Prefix),
+			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q; multiple allowed)", re2Prefix),
 			Description: "delay, loss, duplicate and re-order (run 'netem') packets, and limit the bandwidth, to emulate different network problems",
 			Subcommands: []cli.Command{
 				*netemCmd.NewDelayCLICommand(topContext, runtime),
@@ -122,7 +122,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 			},
 			Usage:       "apply IPv4 packet filter on incoming IP packets",
-			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", re2Prefix),
+			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q; multiple allowed)", re2Prefix),
 			Description: "emulate loss of incoming packets, all ports and address arguments will result in separate rules",
 			Subcommands: []cli.Command{
 				*ipTablesCmd.NewLossCLICommand(topContext, runtime),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 	app.EnableBashCompletion = true
 	app.Usage = "Pumba is a resilience testing tool, that helps applications tolerate random Docker container failures: process, network and performance."
-	app.ArgsUsage = fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q)", re2Prefix)
+	app.ArgsUsage = fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q; multiple allowed)", re2Prefix)
 	app.Before = before
 	app.After = func(_ *cli.Context) error {
 		if runtimeClient != nil {

--- a/pkg/chaos/command.go
+++ b/pkg/chaos/command.go
@@ -31,7 +31,7 @@ type Command interface {
 type GlobalParams struct {
 	Random     bool
 	Labels     []string
-	Pattern    string
+	Patterns   []string
 	Names      []string
 	Interval   time.Duration
 	DryRun     bool
@@ -58,11 +58,11 @@ func splitLabels(raw []string) []string {
 // subcommand-level Flags directly.
 func ParseGlobalParams(c cliflags.Flags) *GlobalParams {
 	g := c.Global()
-	names, pattern := getNamesOrPattern(c)
+	names, patterns := getNamesOrPattern(c)
 	return &GlobalParams{
 		Random:     g.Bool("random"),
 		Labels:     splitLabels(g.StringSlice("label")),
-		Pattern:    pattern,
+		Patterns:   patterns,
 		Names:      names,
 		DryRun:     g.Bool("dry-run"),
 		SkipErrors: g.Bool("skip-error"),
@@ -70,30 +70,31 @@ func ParseGlobalParams(c cliflags.Flags) *GlobalParams {
 	}
 }
 
-// get names list of filter pattern from command line
-func getNamesOrPattern(c cliflags.Flags) ([]string, string) {
+// getNamesOrPattern splits CLI arguments into names and regex patterns.
+// Arguments prefixed with "re2:" are treated as regex patterns; the rest are
+// exact container names. Multiple patterns and names may be mixed freely.
+func getNamesOrPattern(c cliflags.Flags) ([]string, []string) {
 	var names []string
-	pattern := ""
+	var patterns []string
 	args := c.Args()
 	// no Args means ALL containers
 	if len(args) == 0 {
-		return names, pattern
+		return names, patterns
 	}
-	// more than one argument, assume that this a list of names
-	if len(args) > 1 {
-		names = args
+	for _, arg := range args {
+		if rest, found := strings.CutPrefix(arg, Re2Prefix); found {
+			patterns = append(patterns, rest)
+		} else {
+			names = append(names, arg)
+		}
+	}
+	if len(patterns) > 0 {
+		log.WithField("patterns", patterns).Debug("using patterns")
+	}
+	if len(names) > 0 {
 		log.WithField("names", names).Debug("using names")
-		return names, pattern
 	}
-	first := args[0]
-	if rest, found := strings.CutPrefix(first, Re2Prefix); found {
-		pattern = rest
-		log.WithField("pattern", pattern).Debug("using pattern")
-		return names, pattern
-	}
-	names = append(names, first)
-	log.WithField("names", names).Debug("using names")
-	return names, pattern
+	return names, patterns
 }
 
 // RunChaosCommand run chaos command in go routine

--- a/pkg/chaos/command_test.go
+++ b/pkg/chaos/command_test.go
@@ -144,45 +144,57 @@ func TestGetNamesOrPattern(t *testing.T) {
 		name        string
 		args        []string
 		wantNames   []string
-		wantPattern string
+		wantPatterns []string
 	}{
 		{
-			name:        "no args — target all containers",
-			args:        nil,
-			wantNames:   nil,
-			wantPattern: "",
+			name:         "no args — target all containers",
+			args:         nil,
+			wantNames:    nil,
+			wantPatterns: nil,
 		},
 		{
-			name:        "single plain name",
-			args:        []string{"web"},
-			wantNames:   []string{"web"},
-			wantPattern: "",
+			name:         "single plain name",
+			args:         []string{"web"},
+			wantNames:    []string{"web"},
+			wantPatterns: nil,
 		},
 		{
-			name:        "multiple names",
-			args:        []string{"web", "db", "cache"},
-			wantNames:   []string{"web", "db", "cache"},
-			wantPattern: "",
+			name:         "multiple names",
+			args:         []string{"web", "db", "cache"},
+			wantNames:    []string{"web", "db", "cache"},
+			wantPatterns: nil,
 		},
 		{
-			name:        "re2 prefix yields pattern",
-			args:        []string{"re2:^app-"},
-			wantNames:   nil,
-			wantPattern: "^app-",
+			name:         "re2 prefix yields pattern",
+			args:         []string{"re2:^app-"},
+			wantNames:    nil,
+			wantPatterns: []string{"^app-"},
 		},
 		{
-			name:        "re2 prefix with empty pattern",
-			args:        []string{"re2:"},
-			wantNames:   nil,
-			wantPattern: "",
+			name:         "re2 prefix with empty pattern",
+			args:         []string{"re2:"},
+			wantNames:    nil,
+			wantPatterns: []string{""},
+		},
+		{
+			name:         "multiple re2 patterns",
+			args:         []string{"re2:^web-", "re2:^api-"},
+			wantNames:    nil,
+			wantPatterns: []string{"^web-", "^api-"},
+		},
+		{
+			name:         "mixed names and patterns",
+			args:         []string{"re2:^web-", "nginx", "re2:^api-"},
+			wantNames:    []string{"nginx"},
+			wantPatterns: []string{"^web-", "^api-"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := buildFlags(t, nil, nil, nil, tt.args)
-			names, pattern := getNamesOrPattern(f)
+			names, patterns := getNamesOrPattern(f)
 			assert.Equal(t, tt.wantNames, names)
-			assert.Equal(t, tt.wantPattern, pattern)
+			assert.Equal(t, tt.wantPatterns, patterns)
 		})
 	}
 }
@@ -213,7 +225,7 @@ func TestParseGlobalParams(t *testing.T) {
 				Interval:   0,
 				Labels:     nil,
 				Names:      nil,
-				Pattern:    "",
+				Patterns:   nil,
 			},
 		},
 		{
@@ -263,7 +275,7 @@ func TestParseGlobalParams(t *testing.T) {
 			globalArgs: nil,
 			childArgs:  []string{"re2:^app-"},
 			want: &GlobalParams{
-				Pattern: "^app-",
+				Patterns: []string{"^app-"},
 			},
 		},
 	}
@@ -290,8 +302,8 @@ func TestParseGlobalParams(t *testing.T) {
 			if tt.want.Names != nil {
 				assert.Equal(t, tt.want.Names, got.Names)
 			}
-			if tt.want.Pattern != "" {
-				assert.Equal(t, tt.want.Pattern, got.Pattern)
+			if tt.want.Patterns != nil {
+				assert.Equal(t, tt.want.Patterns, got.Patterns)
 			}
 		})
 	}

--- a/pkg/chaos/iptables/loss.go
+++ b/pkg/chaos/iptables/loss.go
@@ -78,7 +78,7 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network random packet loss to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/lifecycle/exec.go
+++ b/pkg/chaos/lifecycle/exec.go
@@ -19,7 +19,7 @@ type execClient interface {
 type execCommand struct {
 	client  execClient
 	names   []string
-	pattern string
+	patterns []string
 	labels  []string
 	command string
 	args    []string
@@ -32,7 +32,7 @@ func NewExecCommand(client execClient, params *chaos.GlobalParams, command strin
 	exec := &execCommand{
 		client:  client,
 		names:   params.Names,
-		pattern: params.Pattern,
+		patterns: params.Patterns,
 		labels:  params.Labels,
 		command: command,
 		args:    args,
@@ -50,12 +50,12 @@ func (k *execCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("execing all matching containers")
 	log.WithFields(log.Fields{
 		"names":   k.names,
-		"pattern": k.pattern,
+		"patterns": k.patterns,
 		"labels":  k.labels,
 		"limit":   k.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
-	gp := &chaos.GlobalParams{Names: k.names, Pattern: k.pattern, Labels: k.labels}
+	gp := &chaos.GlobalParams{Names: k.names, Patterns: k.patterns, Labels: k.labels}
 	return chaos.RunOnContainers(ctx, k.client, gp, k.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {
 			log.WithFields(log.Fields{"c": *c, "command": k.command, "args": k.args}).Debug("execing c")

--- a/pkg/chaos/lifecycle/exec_test.go
+++ b/pkg/chaos/lifecycle/exec_test.go
@@ -65,7 +65,7 @@ func TestExecCommand_Run(t *testing.T) {
 			name: "exec matching containers by filter with limit",
 			fields: fields{
 				params: &chaos.GlobalParams{
-					Pattern: "^c?",
+					Patterns: []string{"^c?"},
 				},
 				command: "kill",
 				args:    []string{"-STOP", "1"},
@@ -131,7 +131,7 @@ func TestExecCommand_Run(t *testing.T) {
 			k := &execCommand{
 				client:  mockClient,
 				names:   tt.fields.params.Names,
-				pattern: tt.fields.params.Pattern,
+				patterns: tt.fields.params.Patterns,
 				labels:  tt.fields.params.Labels,
 				command: tt.fields.command,
 				args:    tt.fields.args,
@@ -179,13 +179,13 @@ func TestNewExecCommand(t *testing.T) {
 	}{
 		{
 			name:    "fields propagated",
-			params:  &chaos.GlobalParams{Names: []string{"c1"}, Pattern: "^c", Labels: []string{"k=v"}, DryRun: true},
+			params:  &chaos.GlobalParams{Names: []string{"c1"}, Patterns: []string{"^c?"}, Labels: []string{"k=v"}, DryRun: true},
 			command: "ls",
 			args:    []string{"-la"},
 			limit:   3,
 			want: &execCommand{
 				names:   []string{"c1"},
-				pattern: "^c",
+patterns:  []string{"^c?"},
 				labels:  []string{"k=v"},
 				command: "ls",
 				args:    []string{"-la"},

--- a/pkg/chaos/lifecycle/kill.go
+++ b/pkg/chaos/lifecycle/kill.go
@@ -58,7 +58,7 @@ type killClient interface {
 type killCommand struct {
 	client  killClient
 	names   []string
-	pattern string
+	patterns []string
 	labels  []string
 	signal  string
 	limit   int
@@ -70,7 +70,7 @@ func NewKillCommand(client killClient, params *chaos.GlobalParams, signal string
 	kill := &killCommand{
 		client:  client,
 		names:   params.Names,
-		pattern: params.Pattern,
+		patterns: params.Patterns,
 		labels:  params.Labels,
 		signal:  signal,
 		limit:   limit,
@@ -89,13 +89,13 @@ func NewKillCommand(client killClient, params *chaos.GlobalParams, signal string
 func (k *killCommand) Run(ctx context.Context, random bool) error {
 	log.WithFields(log.Fields{
 		"names":   k.names,
-		"pattern": k.pattern,
+		"patterns": k.patterns,
 		"labels":  k.labels,
 		"signal":  k.signal,
 		"limit":   k.limit,
 		"random":  random,
 	}).Debug("killing all matching containers")
-	gp := &chaos.GlobalParams{Names: k.names, Pattern: k.pattern, Labels: k.labels}
+	gp := &chaos.GlobalParams{Names: k.names, Patterns: k.patterns, Labels: k.labels}
 	return chaos.RunOnContainers(ctx, k.client, gp, k.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {
 			log.WithFields(log.Fields{"ctr": c, "signal": k.signal}).Debug("killing ctr")

--- a/pkg/chaos/lifecycle/kill_test.go
+++ b/pkg/chaos/lifecycle/kill_test.go
@@ -20,7 +20,7 @@ func TestKillCommand_Run(t *testing.T) {
 	}
 	type fields struct {
 		names   []string
-		pattern string
+		patterns []string
 		labels  []string
 		signal  string
 		limit   int
@@ -60,7 +60,7 @@ func TestKillCommand_Run(t *testing.T) {
 		{
 			name: "kill matching containers by filter with limit",
 			fields: fields{
-				pattern: "^c?",
+				patterns:  []string{"^c?"},
 				signal:  "SIGSTOP",
 				limit:   2,
 			},
@@ -112,7 +112,7 @@ func TestKillCommand_Run(t *testing.T) {
 			k := &killCommand{
 				client:  mockClient,
 				names:   tt.fields.names,
-				pattern: tt.fields.pattern,
+				patterns: tt.fields.patterns,
 				labels:  tt.fields.labels,
 				signal:  tt.fields.signal,
 				limit:   tt.fields.limit,

--- a/pkg/chaos/lifecycle/pause.go
+++ b/pkg/chaos/lifecycle/pause.go
@@ -22,7 +22,7 @@ type pauseClient interface {
 type pauseCommand struct {
 	client   pauseClient
 	names    []string
-	pattern  string
+	patterns []string
 	labels   []string
 	duration time.Duration
 	limit    int
@@ -34,7 +34,7 @@ func NewPauseCommand(client pauseClient, params *chaos.GlobalParams, duration ti
 	return &pauseCommand{
 		client:   client,
 		names:    params.Names,
-		pattern:  params.Pattern,
+		patterns: params.Patterns,
 		labels:   params.Labels,
 		duration: duration,
 		limit:    limit,
@@ -46,13 +46,13 @@ func (p *pauseCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("pausing all matching containers")
 	log.WithFields(log.Fields{
 		"names":    p.names,
-		"pattern":  p.pattern,
+		"patterns":  p.patterns,
 		"labels":   p.labels,
 		"duration": p.duration,
 		"limit":    p.limit,
 		"random":   random,
 	}).Debug("listing matching containers")
-	gp := &chaos.GlobalParams{Names: p.names, Pattern: p.pattern, Labels: p.labels}
+	gp := &chaos.GlobalParams{Names: p.names, Patterns: p.patterns, Labels: p.labels}
 	pausedContainers := make([]*container.Container, 0)
 	err := chaos.RunOnContainers(ctx, p.client, gp, p.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/lifecycle/pause_test.go
+++ b/pkg/chaos/lifecycle/pause_test.go
@@ -22,7 +22,7 @@ func TestPauseCommand_Run(t *testing.T) {
 	}
 	type fields struct {
 		names   []string
-		pattern string
+	patterns []string
 		limit   int
 		dryRun  bool
 	}
@@ -49,7 +49,7 @@ func TestPauseCommand_Run(t *testing.T) {
 		{
 			name: "pause matching containers by filter with limit",
 			fields: fields{
-				pattern: "^c?",
+				patterns:  []string{"^c?"},
 				limit:   2,
 			},
 			args:     args{ctx: context.TODO()},
@@ -106,7 +106,7 @@ func TestPauseCommand_Run(t *testing.T) {
 			s := &pauseCommand{
 				client:  mockClient,
 				names:   tt.fields.names,
-				pattern: tt.fields.pattern,
+				patterns:  tt.fields.patterns,
 				limit:   tt.fields.limit,
 				dryRun:  tt.fields.dryRun,
 			}
@@ -156,12 +156,12 @@ func TestNewPauseCommand(t *testing.T) {
 	}{
 		{
 			name:     "fields propagated",
-			params:   &chaos.GlobalParams{Names: []string{"c1"}, Pattern: "^c", Labels: []string{"k=v"}, DryRun: true},
+			params:   &chaos.GlobalParams{Names: []string{"c1"}, Patterns: []string{"^c"}, Labels: []string{"k=v"}, DryRun: true},
 			duration: 3 * time.Second,
 			limit:    2,
 			want: &pauseCommand{
 				names:    []string{"c1"},
-				pattern:  "^c",
+				patterns:  []string{"^c"},
 				labels:   []string{"k=v"},
 				duration: 3 * time.Second,
 				limit:    2,

--- a/pkg/chaos/lifecycle/remove.go
+++ b/pkg/chaos/lifecycle/remove.go
@@ -19,7 +19,7 @@ type removeClient interface {
 type removeCommand struct {
 	client  removeClient
 	names   []string
-	pattern string
+	patterns []string
 	labels  []string
 	opts    container.RemoveOpts
 	limit   int
@@ -30,7 +30,7 @@ func NewRemoveCommand(client removeClient, params *chaos.GlobalParams, force, li
 	remove := &removeCommand{
 		client:  client,
 		names:   params.Names,
-		pattern: params.Pattern,
+		patterns: params.Patterns,
 		labels:  params.Labels,
 		opts: container.RemoveOpts{
 			Force:   force,
@@ -48,12 +48,12 @@ func (r *removeCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("removing all matching containers")
 	log.WithFields(log.Fields{
 		"names":   r.names,
-		"pattern": r.pattern,
+		"patterns": r.patterns,
 		"labels":  r.labels,
 		"limit":   r.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
-	gp := &chaos.GlobalParams{Names: r.names, Pattern: r.pattern, Labels: r.labels}
+	gp := &chaos.GlobalParams{Names: r.names, Patterns: r.patterns, Labels: r.labels}
 	return chaos.RunOnContainersAll(ctx, r.client, gp, r.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {
 			log.WithFields(log.Fields{

--- a/pkg/chaos/lifecycle/remove_test.go
+++ b/pkg/chaos/lifecycle/remove_test.go
@@ -20,7 +20,7 @@ func TestRemoveCommand_Run(t *testing.T) {
 	}
 	type fields struct {
 		names   []string
-		pattern string
+		patterns []string
 		force   bool
 		links   bool
 		volumes bool
@@ -51,7 +51,7 @@ func TestRemoveCommand_Run(t *testing.T) {
 		{
 			name: "remove matching containers by filter with limit",
 			fields: fields{
-				pattern: "^c?",
+				patterns:  []string{"^c?"},
 				force:   true,
 				links:   true,
 				limit:   2,
@@ -109,7 +109,7 @@ func TestRemoveCommand_Run(t *testing.T) {
 			k := &removeCommand{
 				client:  mockClient,
 				names:   tt.fields.names,
-				pattern: tt.fields.pattern,
+				patterns: tt.fields.patterns,
 				opts:    opts,
 				limit:   tt.fields.limit,
 			}
@@ -154,14 +154,14 @@ func TestNewRemoveCommand(t *testing.T) {
 	}{
 		{
 			name:    "all opts true",
-			params:  &chaos.GlobalParams{Names: []string{"c1"}, Pattern: "^c", Labels: []string{"k=v"}, DryRun: true},
+			params:  &chaos.GlobalParams{Names: []string{"c1"}, Patterns: []string{"^c"}, Labels: []string{"k=v"}, DryRun: true},
 			force:   true,
 			links:   true,
 			volumes: true,
 			limit:   5,
 			want: &removeCommand{
 				names:   []string{"c1"},
-				pattern: "^c",
+				patterns:  []string{"^c"},
 				labels:  []string{"k=v"},
 				opts:    container.RemoveOpts{Force: true, Links: true, Volumes: true, DryRun: true},
 				limit:   5,

--- a/pkg/chaos/lifecycle/restart.go
+++ b/pkg/chaos/lifecycle/restart.go
@@ -20,7 +20,7 @@ type restartClient interface {
 type restartCommand struct {
 	client  restartClient
 	names   []string
-	pattern string
+	patterns []string
 	labels  []string
 	timeout time.Duration
 	limit   int
@@ -32,7 +32,7 @@ func NewRestartCommand(client restartClient, params *chaos.GlobalParams, timeout
 	return &restartCommand{
 		client:  client,
 		names:   params.Names,
-		pattern: params.Pattern,
+		patterns: params.Patterns,
 		labels:  params.Labels,
 		timeout: timeout,
 		limit:   limit,
@@ -45,12 +45,12 @@ func (k *restartCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("restarting all matching containers")
 	log.WithFields(log.Fields{
 		"names":   k.names,
-		"pattern": k.pattern,
+		"patterns": k.patterns,
 		"labels":  k.labels,
 		"limit":   k.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
-	gp := &chaos.GlobalParams{Names: k.names, Pattern: k.pattern, Labels: k.labels}
+	gp := &chaos.GlobalParams{Names: k.names, Patterns: k.patterns, Labels: k.labels}
 	return chaos.RunOnContainers(ctx, k.client, gp, k.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {
 			log.WithFields(log.Fields{"container": c, "timeout": k.timeout}).Debug("restarting container")

--- a/pkg/chaos/lifecycle/restart_test.go
+++ b/pkg/chaos/lifecycle/restart_test.go
@@ -21,7 +21,7 @@ func TestRestartCommand_Run(t *testing.T) {
 	}
 	type fields struct {
 		names   []string
-		pattern string
+		patterns []string
 		labels  []string
 		timeout time.Duration
 		limit   int
@@ -61,7 +61,7 @@ func TestRestartCommand_Run(t *testing.T) {
 		{
 			name: "restart matching containers by filter with limit",
 			fields: fields{
-				pattern: "^c?",
+				patterns:  []string{"^c?"},
 				timeout: 1 * time.Second,
 				limit:   2,
 			},
@@ -113,7 +113,7 @@ func TestRestartCommand_Run(t *testing.T) {
 			k := &restartCommand{
 				client:  mockClient,
 				names:   tt.fields.names,
-				pattern: tt.fields.pattern,
+				patterns: tt.fields.patterns,
 				labels:  tt.fields.labels,
 				timeout: 1 * time.Second,
 				limit:   tt.fields.limit,
@@ -159,12 +159,12 @@ func TestNewRestartCommand(t *testing.T) {
 	}{
 		{
 			name:    "fields propagated",
-			params:  &chaos.GlobalParams{Names: []string{"c1"}, Pattern: "^c", Labels: []string{"k=v"}, DryRun: true},
+			params:  &chaos.GlobalParams{Names: []string{"c1"}, Patterns: []string{"^c"}, Labels: []string{"k=v"}, DryRun: true},
 			timeout: 5 * time.Second,
 			limit:   2,
 			want: &restartCommand{
 				names:   []string{"c1"},
-				pattern: "^c",
+				patterns:  []string{"^c"},
 				labels:  []string{"k=v"},
 				timeout: 5 * time.Second,
 				limit:   2,

--- a/pkg/chaos/lifecycle/stop.go
+++ b/pkg/chaos/lifecycle/stop.go
@@ -27,7 +27,7 @@ type stopClient interface {
 type stopCommand struct {
 	client   stopClient
 	names    []string
-	pattern  string
+	patterns []string
 	labels   []string
 	restart  bool
 	duration time.Duration
@@ -44,7 +44,7 @@ func NewStopCommand(client stopClient, params *chaos.GlobalParams, restart bool,
 	return &stopCommand{
 		client:   client,
 		names:    params.Names,
-		pattern:  params.Pattern,
+		patterns: params.Patterns,
 		labels:   params.Labels,
 		dryRun:   params.DryRun,
 		restart:  restart,
@@ -57,14 +57,14 @@ func NewStopCommand(client stopClient, params *chaos.GlobalParams, restart bool,
 func (s *stopCommand) Run(ctx context.Context, random bool) error {
 	log.WithFields(log.Fields{
 		"names":    s.names,
-		"pattern":  s.pattern,
+		"patterns":  s.patterns,
 		"labels":   s.labels,
 		"duration": s.duration,
 		"waitTime": s.waitTime,
 		"limit":    s.limit,
 		"random":   random,
 	}).Debug("stopping all matching containers")
-	gp := &chaos.GlobalParams{Names: s.names, Pattern: s.pattern, Labels: s.labels}
+	gp := &chaos.GlobalParams{Names: s.names, Patterns: s.patterns, Labels: s.labels}
 	stoppedContainers := make([]*container.Container, 0)
 	err := chaos.RunOnContainers(ctx, s.client, gp, s.limit, random, false,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/lifecycle/stop_test.go
+++ b/pkg/chaos/lifecycle/stop_test.go
@@ -22,7 +22,7 @@ func TestStopCommand_Run(t *testing.T) {
 	}
 	type fields struct {
 		names    []string
-		pattern  string
+		patterns []string
 		restart  bool
 		waitTime int
 		limit    int
@@ -62,7 +62,7 @@ func TestStopCommand_Run(t *testing.T) {
 		{
 			name: "stop matching containers by filter with limit",
 			fields: fields{
-				pattern:  "^c?",
+				patterns:  []string{"^c?"},
 				waitTime: 20,
 				limit:    2,
 			},
@@ -136,7 +136,7 @@ func TestStopCommand_Run(t *testing.T) {
 			s := &stopCommand{
 				client:   mockClient,
 				names:    tt.fields.names,
-				pattern:  tt.fields.pattern,
+				patterns:  tt.fields.patterns,
 				restart:  tt.fields.restart,
 				waitTime: tt.fields.waitTime,
 				limit:    tt.fields.limit,
@@ -194,14 +194,14 @@ func TestNewStopCommand(t *testing.T) {
 	}{
 		{
 			name:     "fields propagated",
-			params:   &chaos.GlobalParams{Names: []string{"c1"}, Pattern: "^c", Labels: []string{"k=v"}, DryRun: true},
+			params:   &chaos.GlobalParams{Names: []string{"c1"}, Patterns: []string{"^c"}, Labels: []string{"k=v"}, DryRun: true},
 			restart:  true,
 			duration: 5 * time.Second,
 			waitTime: 10,
 			limit:    3,
 			want: &stopCommand{
 				names:    []string{"c1"},
-				pattern:  "^c",
+				patterns:  []string{"^c"},
 				labels:   []string{"k=v"},
 				restart:  true,
 				duration: 5 * time.Second,

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -54,7 +54,7 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network random packet corrupt to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -72,7 +72,7 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network delay to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -58,7 +58,7 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network random packet duplicates to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -53,7 +53,7 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network random packet loss to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -69,7 +69,7 @@ func (n *lossGECommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network packet loss according Gilbert-Elliot model to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -76,7 +76,7 @@ func (n *lossStateCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("adding network packet loss according 4-state Markov model to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -75,7 +75,7 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 	log.Debug("setting network rate to all matching containers")
 	log.WithFields(log.Fields{
 		"names":   n.gp.Names,
-		"pattern": n.gp.Pattern,
+		"patterns": n.gp.Patterns,
 		"labels":  n.gp.Labels,
 		"limit":   n.limit,
 		"random":  random,

--- a/pkg/chaos/runner.go
+++ b/pkg/chaos/runner.go
@@ -68,7 +68,7 @@ func runOnContainers(
 	all, random, parallel bool,
 	fn ContainerAction,
 ) error {
-	containers, err := container.ListNContainersAll(ctx, lister, gp.Names, gp.Pattern, gp.Labels, limit, all)
+	containers, err := container.ListNContainersAll(ctx, lister, gp.Names, gp.Patterns, gp.Labels, limit, all)
 	if err != nil {
 		return fmt.Errorf("listing containers: %w", err)
 	}

--- a/pkg/chaos/runner_test.go
+++ b/pkg/chaos/runner_test.go
@@ -185,7 +185,7 @@ func TestRunOnContainers_PassesLabelsAndPatternToLister(t *testing.T) {
 	mockClient := container.NewMockClient(t)
 	gp := &chaos.GlobalParams{
 		Names:   nil,
-		Pattern: "web-.*",
+		Patterns: []string{"web-.*"},
 		Labels:  []string{"role=api"},
 	}
 	cs := makeContainers("web-1")

--- a/pkg/chaos/stress/stress.go
+++ b/pkg/chaos/stress/stress.go
@@ -22,7 +22,7 @@ type stressClient interface {
 type stressCommand struct {
 	client       stressClient
 	names        []string
-	pattern      string
+	patterns     []string
 	labels       []string
 	image        string
 	pull         bool
@@ -42,7 +42,7 @@ func NewStressCommand(client stressClient, globalParams *chaos.GlobalParams, ima
 	stress := &stressCommand{
 		client:       client,
 		names:        globalParams.Names,
-		pattern:      globalParams.Pattern,
+		patterns:     globalParams.Patterns,
 		labels:       globalParams.Labels,
 		image:        image,
 		pull:         pull,
@@ -59,14 +59,14 @@ func NewStressCommand(client stressClient, globalParams *chaos.GlobalParams, ima
 func (s *stressCommand) Run(ctx context.Context, random bool) error {
 	log.WithFields(log.Fields{
 		"names":     s.names,
-		"pattern":   s.pattern,
+		"patterns":   s.patterns,
 		"labels":    s.labels,
 		"duration":  s.duration,
 		"stressors": s.stressors,
 		"limit":     s.limit,
 		"random":    random,
 	}).Debug("stress testing all matching containers")
-	gp := &chaos.GlobalParams{Names: s.names, Pattern: s.pattern, Labels: s.labels}
+	gp := &chaos.GlobalParams{Names: s.names, Patterns: s.patterns, Labels: s.labels}
 	if err := chaos.RunOnContainers(ctx, s.client, gp, s.limit, random, true, s.stressContainer); err != nil {
 		return fmt.Errorf("one or more stress test failed: %w", err)
 	}

--- a/pkg/container/filter.go
+++ b/pkg/container/filter.go
@@ -20,18 +20,22 @@ func matchNames(names []string, containerName, containerID string) bool {
 	return false
 }
 
-// matchPattern checks if containerName matches the given regex pattern.
+// matchPatterns checks if containerName matches any of the given regex patterns.
 // Container names may start with a forward slash when using inspect function.
-func matchPattern(pattern, containerName string) bool {
-	matched, err := regexp.MatchString(pattern, containerName)
-	if err != nil {
-		return false
+func matchPatterns(patterns []string, containerName string) bool {
+	for _, pattern := range patterns {
+		matched, err := regexp.MatchString(pattern, containerName)
+		if err != nil {
+			continue
+		}
+		if !matched && strings.HasPrefix(containerName, "/") {
+			matched, _ = regexp.MatchString(pattern, containerName[1:])
+		}
+		if matched {
+			return true
+		}
 	}
-	if !matched && strings.HasPrefix(containerName, "/") {
-		// pattern already compiled once above without error; ignore err here
-		matched, _ = regexp.MatchString(pattern, containerName[1:])
-	}
-	return matched
+	return false
 }
 
 // applyContainerFilter creates a FilterFunc from a filter config.
@@ -45,6 +49,6 @@ func applyContainerFilter(flt filter) FilterFunc {
 		if len(flt.Names) > 0 {
 			return matchNames(flt.Names, c.ContainerName, c.ContainerID)
 		}
-		return matchPattern(flt.Pattern, c.ContainerName)
+		return matchPatterns(flt.Patterns, c.ContainerName)
 	}
 }

--- a/pkg/container/filter_test.go
+++ b/pkg/container/filter_test.go
@@ -71,43 +71,43 @@ func TestMatchNames(t *testing.T) {
 func TestMatchPattern(t *testing.T) {
 	tests := []struct {
 		name          string
-		pattern       string
+		patterns      []string
 		containerName string
 		expected      bool
 	}{
 		{
 			name:          "empty container name",
-			pattern:       "container[0-9]",
+			patterns:      []string{"container[0-9]"},
 			containerName: "",
 			expected:      false,
 		},
 		{
 			name:          "exact match",
-			pattern:       "container1",
+			patterns:      []string{"container1"},
 			containerName: "container1",
 			expected:      true,
 		},
 		{
 			name:          "regex match",
-			pattern:       "container[0-9]",
+			patterns:      []string{"container[0-9]"},
 			containerName: "container1",
 			expected:      true,
 		},
 		{
 			name:          "no match",
-			pattern:       "container[0-9]",
+			patterns:      []string{"container[0-9]"},
 			containerName: "containerX",
 			expected:      false,
 		},
 		{
 			name:          "match with leading slash",
-			pattern:       "container[0-9]",
+			patterns:      []string{"container[0-9]"},
 			containerName: "/container1",
 			expected:      true,
 		},
 		{
 			name:          "invalid regex pattern",
-			pattern:       "container[",
+			patterns:      []string{"container["},
 			containerName: "container1",
 			expected:      false,
 		},
@@ -115,7 +115,7 @@ func TestMatchPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := matchPattern(tt.pattern, tt.containerName)
+			result := matchPatterns(tt.patterns, tt.containerName)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -185,7 +185,7 @@ func TestApplyContainerFilter(t *testing.T) {
 				Labels:        map[string]string{},
 				Networks:      map[string]NetworkLink{},
 			},
-			filter:   filter{Pattern: "^app-", Opts: ListOpts{All: true}},
+			filter:   filter{Patterns: []string{"^app-"}, Opts: ListOpts{All: true}},
 			expected: true,
 		},
 		{
@@ -195,7 +195,7 @@ func TestApplyContainerFilter(t *testing.T) {
 				Labels:        map[string]string{},
 				Networks:      map[string]NetworkLink{},
 			},
-			filter:   filter{Pattern: "^app-", Opts: ListOpts{All: true}},
+			filter:   filter{Patterns: []string{"^app-"}, Opts: ListOpts{All: true}},
 			expected: false,
 		},
 		{
@@ -205,7 +205,7 @@ func TestApplyContainerFilter(t *testing.T) {
 				Labels:        map[string]string{},
 				Networks:      map[string]NetworkLink{},
 			},
-			filter:   filter{Pattern: "^app-", Opts: ListOpts{All: false}},
+			filter:   filter{Patterns: []string{"^app-"}, Opts: ListOpts{All: false}},
 			expected: true,
 		},
 	}

--- a/pkg/container/util.go
+++ b/pkg/container/util.go
@@ -14,15 +14,15 @@ type ListOpts struct {
 
 // list filter
 type filter struct {
-	Names   []string
-	Pattern string
-	Opts    ListOpts
+	Names    []string
+	Patterns []string
+	Opts     ListOpts
 }
 
-func listContainers(ctx context.Context, client Lister, names []string, pattern string, labels []string, all bool) ([]*Container, error) {
+func listContainers(ctx context.Context, client Lister, names []string, patterns []string, labels []string, all bool) ([]*Container, error) {
 	f := filter{
-		Names:   names,
-		Pattern: pattern,
+		Names:    names,
+		Patterns: patterns,
 		Opts: ListOpts{
 			All:    all,
 			Labels: labels,
@@ -44,13 +44,13 @@ func RandomContainer(containers []*Container) *Container {
 }
 
 // ListNContainers list containers up to specified limit
-func ListNContainers(ctx context.Context, client Lister, names []string, pattern string, labels []string, limit int) ([]*Container, error) {
-	return ListNContainersAll(ctx, client, names, pattern, labels, limit, false)
+func ListNContainers(ctx context.Context, client Lister, names []string, patterns []string, labels []string, limit int) ([]*Container, error) {
+	return ListNContainersAll(ctx, client, names, patterns, labels, limit, false)
 }
 
 // ListNContainersAll list containers up to specified limit, optionally including stopped containers
-func ListNContainersAll(ctx context.Context, client Lister, names []string, pattern string, labels []string, limit int, all bool) ([]*Container, error) {
-	containers, err := listContainers(ctx, client, names, pattern, labels, all)
+func ListNContainersAll(ctx context.Context, client Lister, names []string, patterns []string, labels []string, limit int, all bool) ([]*Container, error) {
+	containers, err := listContainers(ctx, client, names, patterns, labels, all)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container/util_test.go
+++ b/pkg/container/util_test.go
@@ -28,7 +28,7 @@ func TestListNContainers(t *testing.T) {
 				return expected
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainersAll(ctx, m, []string{"c0", "c1"}, "", nil, 0, true)
+				return ListNContainersAll(ctx, m, []string{"c0", "c1"}, nil, nil, 0, true)
 			},
 			wantLen: 2,
 		},
@@ -42,7 +42,7 @@ func TestListNContainers(t *testing.T) {
 				return expected
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainers(ctx, m, []string{"c0", "c1"}, "", nil, 0)
+				return ListNContainers(ctx, m, []string{"c0", "c1"}, nil, nil, 0)
 			},
 			wantLen: 2,
 		},
@@ -54,7 +54,7 @@ func TestListNContainers(t *testing.T) {
 				return nil
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainersAll(ctx, m, []string{"c0"}, "", nil, 0, true)
+				return ListNContainersAll(ctx, m, []string{"c0"}, nil, nil, 0, true)
 			},
 			wantErr: true,
 		},
@@ -67,7 +67,7 @@ func TestListNContainers(t *testing.T) {
 				return expected
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainersAll(ctx, m, []string{"c0", "c1", "c2", "c3", "c4"}, "", nil, 2, true)
+				return ListNContainersAll(ctx, m, []string{"c0", "c1", "c2", "c3", "c4"}, nil, nil, 2, true)
 			},
 			wantLen: 2,
 		},
@@ -80,7 +80,7 @@ func TestListNContainers(t *testing.T) {
 				return expected
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainersAll(ctx, m, []string{"c0", "c1", "c2"}, "", nil, 3, false)
+				return ListNContainersAll(ctx, m, []string{"c0", "c1", "c2"}, nil, nil, 3, false)
 			},
 			wantLen: 3,
 		},
@@ -95,7 +95,7 @@ func TestListNContainers(t *testing.T) {
 				return expected
 			},
 			call: func(ctx context.Context, m *MockClient) ([]*Container, error) {
-				return ListNContainers(ctx, m, []string{"c0"}, "", []string{"env=prod", "tier=web"}, 0)
+				return ListNContainers(ctx, m, []string{"c0"}, nil, []string{"env=prod", "tier=web"}, 0)
 			},
 			wantLen: 1,
 		},


### PR DESCRIPTION
## What

Support passing multiple `re2:` prefixed regex patterns for container matching, in addition to the existing single-pattern and name-list modes.

## Why

Closes #179. Users need to target containers matching different naming conventions (e.g., `^web-.*` and `^api-.*`) without resorting to overly broad single patterns or maintaining separate pumba invocations.

## How

- `GlobalParams.Pattern string` → `GlobalParams.Patterns []string`
- `matchPattern()` → `matchPatterns()` — iterates patterns, any match wins
- `getNamesOrPattern()` now iterates all CLI args: `re2:` prefixed args become patterns, the rest become names. This allows mixing freely:
  ```
  pumba kill re2:^web-.* re2:^api-.*            # two patterns
  pumba kill re2:^web-.* nginx re2:^api-.*       # mixed patterns + names
  pumba kill web db cache                         # names (unchanged)
  pumba kill re2:^app-.*                          # single pattern (unchanged)
  ```

## Testing

- All existing unit tests pass (`go test ./pkg/...`)
- Added test cases for multiple patterns and mixed names+patterns in `command_test.go`
- Backward compatible: single `re2:` prefix, single name, and name list all work as before