### PR TITLE
feat(netem): chain netem subcommands to combine effects in a single qdisc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Pumba targets **Linux containers** — every chaos action depends on Linux primi
 | **Network Delay**   | `netem delay`                             | Add latency to egress traffic                                                 |
 | **Packet Loss**     | `netem loss`, `iptables loss`             | Drop packets (egress and ingress)                                             |
 | **Network Effects** | `netem duplicate`, `corrupt`, `rate`      | Duplicate, corrupt, or rate-limit packets                                     |
+| **Combined Effects**| chained `netem` subcommands               | Chain several effects in one invocation, applied as a single qdisc           |
 | **Stress Testing**  | `stress`                                  | CPU, memory, I/O stress via stress-ng (child cgroup or same-cgroup injection) |
 | **Targeting**       | names, regex (`re2:`), labels, `--random` | Flexible container selection                                                  |
 | **Scheduling**      | `--interval`                              | Recurring chaos at fixed intervals                                            |
@@ -95,6 +96,9 @@ pumba --interval=30s --random kill "re2:^test"
 
 # Add 3 seconds network delay to mydb for 5 minutes
 pumba netem --duration 5m delay --time 3000 mydb
+
+# Combine 100ms delay with 20% packet loss on mydb for 5 minutes (chained effects)
+pumba netem --duration 5m delay --time 100 loss --percent 20 mydb
 
 # Drop 10% of incoming packets to myapp for 2 minutes
 pumba iptables --duration 2m loss --probability 0.1 myapp

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -62,7 +62,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 			},
 			Usage:       "emulate the properties of wide area networks",
 			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", re2Prefix),
-			Description: "delay, loss, duplicate and re-order (run 'netem') packets, and limit the bandwidth, to emulate different network problems",
+			Description: "delay, loss, duplicate and re-order (run 'netem') packets, and limit the bandwidth, to emulate different network problems; chain several effects in one invocation to combine them in a single qdisc, e.g. 'netem --duration 5m delay --time 100 loss --percent 20 mycontainer'",
 			Subcommands: []cli.Command{
 				*netemCmd.NewDelayCLICommand(topContext, runtime),
 				*netemCmd.NewLossCLICommand(topContext, runtime),

--- a/docs/network-chaos.md
+++ b/docs/network-chaos.md
@@ -185,6 +185,28 @@ pumba netem --duration 10m rate --rate 1mbit --packetoverhead 20 mydb
 
 Options: `--rate` (e.g., `100kbit`, `1mbit`), `--packetoverhead` (bytes), `--cellsize` (bytes), `--celloverhead` (bytes).
 
+### Combining effects (chaining)
+
+Chain several netem subcommands in **one invocation** to combine them in a **single** netem qdisc. Only one root netem qdisc can exist per interface, so this is the way to apply several effects to the same container at once — running separate `netem delay` and `netem loss` processes against the same target fails.
+
+Each chained effect uses its normal subcommand name, flags, and defaults; whatever follows the last effect's flags is the container list (or `re2:` pattern), exactly as usual.
+
+```bash
+# Add 100ms delay AND 20% packet loss to mydb for 5 minutes
+pumba netem --duration 5m delay --time 100 loss --percent 20 mydb
+
+# Full degradation: delay + jitter, loss, corruption and a bandwidth cap
+pumba netem --duration 10m \
+    delay --time 100 --jitter 10 \
+    loss --percent 20 corrupt --percent 5 rate --rate 1mbit myapp
+```
+
+Chainable effects: `delay`, `loss`, `corrupt`, `duplicate`, `rate`. Notes:
+
+- The same effect cannot appear twice in a chain.
+- `loss-state` and `loss-gemodel` cannot be chained — loss models are mutually exclusive on a single qdisc.
+- Effect keywords take precedence over container names: to target a container literally named `loss`, use `re2:^loss$`.
+
 ## IPTables Commands
 
 The `iptables` command manipulates **incoming** traffic by adding packet filtering rules. All iptables commands support these common options:

--- a/pkg/chaos/command.go
+++ b/pkg/chaos/command.go
@@ -72,9 +72,15 @@ func ParseGlobalParams(c cliflags.Flags) *GlobalParams {
 
 // get names list of filter pattern from command line
 func getNamesOrPattern(c cliflags.Flags) ([]string, string) {
+	return NamesOrPattern(c.Args())
+}
+
+// NamesOrPattern splits positional CLI args into explicit container names or
+// a single re2: regex pattern. Exported for parsers that re-derive targets
+// after consuming extra tokens from the arg list (netem effect chaining).
+func NamesOrPattern(args []string) ([]string, string) {
 	var names []string
 	pattern := ""
-	args := c.Args()
 	// no Args means ALL containers
 	if len(args) == 0 {
 		return names, pattern

--- a/pkg/chaos/netem/cmd/chain.go
+++ b/pkg/chaos/netem/cmd/chain.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/chaos/cliflags"
+	"github.com/alexei-led/pumba/pkg/chaos/netem"
+	"github.com/urfave/cli"
+)
+
+// effectDef describes a chainable netem effect: its subcommand name, its flag
+// definitions (the same list used by the CLI subcommand, so names, aliases and
+// defaults stay identical), and how a parsed segment is applied onto the
+// combined EffectsSpec.
+type effectDef struct {
+	name  string
+	flags func() []cli.Flag
+	apply func(f cliflags.Flags, spec *netem.EffectsSpec) error
+}
+
+// netemEffects registers every chainable netem effect keyword.
+func netemEffects() []effectDef {
+	return []effectDef{
+		{name: "delay", flags: delayFlags, apply: applyDelay},
+		{name: "loss", flags: lossFlags, apply: applyLoss},
+		{name: "corrupt", flags: corruptFlags, apply: applyCorrupt},
+		{name: "duplicate", flags: duplicateFlags, apply: applyDuplicate},
+		{name: "rate", flags: rateFlags, apply: applyRate},
+	}
+}
+
+// lossModelNames are netem subcommands that are recognized as effect keywords
+// but cannot be chained: loss-state and loss-gemodel are alternative loss
+// models, mutually exclusive with random loss and with each other on a single
+// netem qdisc.
+func isNonChainableEffect(name string) bool {
+	return name == "loss-state" || name == "loss-gemodel"
+}
+
+func effectByName(name string) (effectDef, bool) {
+	for _, def := range netemEffects() {
+		if def.name == name {
+			return def, true
+		}
+	}
+	return effectDef{}, false
+}
+
+func applyDelay(f cliflags.Flags, spec *netem.EffectsSpec) error {
+	if spec.Delay != nil {
+		return fmt.Errorf("duplicate netem effect %q in chain", "delay")
+	}
+	spec.Delay = &netem.DelaySpec{
+		Time:         f.Int("time"),
+		Jitter:       f.Int("jitter"),
+		Correlation:  f.Float64("correlation"),
+		Distribution: f.String("distribution"),
+	}
+	return nil
+}
+
+func applyLoss(f cliflags.Flags, spec *netem.EffectsSpec) error {
+	if spec.Loss != nil {
+		return fmt.Errorf("duplicate netem effect %q in chain", "loss")
+	}
+	spec.Loss = &netem.LossSpec{
+		Percent:     f.Float64("percent"),
+		Correlation: f.Float64("correlation"),
+	}
+	return nil
+}
+
+func applyCorrupt(f cliflags.Flags, spec *netem.EffectsSpec) error {
+	if spec.Corrupt != nil {
+		return fmt.Errorf("duplicate netem effect %q in chain", "corrupt")
+	}
+	spec.Corrupt = &netem.CorruptSpec{
+		Percent:     f.Float64("percent"),
+		Correlation: f.Float64("correlation"),
+	}
+	return nil
+}
+
+func applyDuplicate(f cliflags.Flags, spec *netem.EffectsSpec) error {
+	if spec.Duplicate != nil {
+		return fmt.Errorf("duplicate netem effect %q in chain", "duplicate")
+	}
+	spec.Duplicate = &netem.DuplicateSpec{
+		Percent:     f.Float64("percent"),
+		Correlation: f.Float64("correlation"),
+	}
+	return nil
+}
+
+func applyRate(f cliflags.Flags, spec *netem.EffectsSpec) error {
+	if spec.Rate != nil {
+		return fmt.Errorf("duplicate netem effect %q in chain", "rate")
+	}
+	spec.Rate = &netem.RateSpec{
+		Rate:           f.String("rate"),
+		PacketOverhead: f.Int("packetoverhead"),
+		CellSize:       f.Int("cellsize"),
+		CellOverhead:   f.Int("celloverhead"),
+	}
+	return nil
+}
+
+// normalizeAliases mirrors urfave/cli v1's unexported normalizeFlags: cli
+// registers every alias of a flag ("percent, p") as a separate Go flag, and
+// after parsing copies the explicitly-set alias's value onto the flag's other
+// names so lookups by canonical name see it. Required here because segments
+// are parsed with a raw flag.FlagSet instead of going through cli.Command.Run.
+func normalizeAliases(flags []cli.Flag, fs *flag.FlagSet) {
+	visited := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { visited[f.Name] = true })
+	for _, fl := range flags {
+		parts := strings.Split(fl.GetName(), ",")
+		if len(parts) == 1 {
+			continue
+		}
+		names := make([]string, 0, len(parts))
+		for _, p := range parts {
+			names = append(names, strings.TrimSpace(p))
+		}
+		setName := ""
+		for _, n := range names {
+			if visited[n] {
+				setName = n
+				break
+			}
+		}
+		if setName == "" {
+			continue
+		}
+		value := fs.Lookup(setName).Value.String()
+		for _, n := range names {
+			if n != setName {
+				_ = fs.Set(n, value) // same flag definition: value is valid for every alias
+			}
+		}
+	}
+}
+
+// chainSpec detects chained effect segments in c.Args(). It reports found ==
+// false when the invocation is a plain single-effect command (leaving the
+// original code path untouched). When the first positional arg is another
+// effect keyword, it applies the primary effect (already parsed from c) plus
+// every chained segment onto a fresh EffectsSpec and re-derives the target
+// names/pattern in gp from the leftover args.
+func chainSpec(c cliflags.Flags, gp *chaos.GlobalParams, primary func(cliflags.Flags, *netem.EffectsSpec) error) (spec netem.EffectsSpec, found bool, err error) {
+	args := c.Args()
+	if len(args) == 0 {
+		return spec, false, nil
+	}
+	if _, chainable := effectByName(args[0]); !chainable && !isNonChainableEffect(args[0]) {
+		return spec, false, nil
+	}
+	if applyErr := primary(c, &spec); applyErr != nil {
+		return spec, false, applyErr
+	}
+	rest, err := parseChain(args, &spec)
+	if err != nil {
+		return spec, false, err
+	}
+	gp.Names, gp.Pattern = chaos.NamesOrPattern(rest)
+	return spec, true, nil
+}
+
+// parseChain consumes effect segments from the front of args. Each segment is
+// parsed with the effect's own cli.Flag definitions (same defaults and aliases
+// as its subcommand); Go's flag parser stops at the first non-flag token, which
+// either starts the next segment or the container names. Returns the leftover
+// (non-effect) args.
+func parseChain(args []string, spec *netem.EffectsSpec) ([]string, error) {
+	for len(args) > 0 {
+		if isNonChainableEffect(args[0]) {
+			return nil, fmt.Errorf("netem effect %q cannot be chained: loss models are mutually exclusive on a single qdisc", args[0])
+		}
+		def, ok := effectByName(args[0])
+		if !ok {
+			return args, nil // container names / re2: pattern
+		}
+		fs := flag.NewFlagSet(def.name, flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		for _, fl := range def.flags() {
+			fl.Apply(fs)
+		}
+		if err := fs.Parse(args[1:]); err != nil {
+			return nil, fmt.Errorf("parsing chained netem effect %q: %w", def.name, err)
+		}
+		normalizeAliases(def.flags(), fs)
+		if err := def.apply(cliflags.NewV1(cli.NewContext(nil, fs, nil)), spec); err != nil {
+			return nil, err
+		}
+		args = fs.Args()
+	}
+	return nil, nil // all args consumed: no explicit targets (match-all / label mode)
+}

--- a/pkg/chaos/netem/cmd/chain_test.go
+++ b/pkg/chaos/netem/cmd/chain_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/chaos/cliflags"
+	"github.com/alexei-led/pumba/pkg/chaos/netem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+// effectCtx builds a cliflags.Flags over the given effect flag definitions,
+// mirroring how urfave/cli hands a subcommand its parsed context.
+func effectCtx(t *testing.T, flags []cli.Flag, args []string) cliflags.Flags {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, fl := range flags {
+		fl.Apply(fs)
+	}
+	require.NoError(t, fs.Parse(args))
+	return cliflags.NewV1(cli.NewContext(nil, fs, nil))
+}
+
+func TestParseChain_SingleSegment(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	rest, err := parseChain([]string{"loss", "--percent", "20", "mydb"}, spec)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mydb"}, rest)
+	require.NotNil(t, spec.Loss)
+	assert.InEpsilon(t, 20.0, spec.Loss.Percent, 1e-9)
+}
+
+func TestParseChain_MultipleSegmentsWithAliases(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	rest, err := parseChain([]string{"loss", "-p", "15", "corrupt", "--percent", "5", "-c", "10", "c1", "c2"}, spec)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c1", "c2"}, rest)
+	require.NotNil(t, spec.Loss)
+	assert.InEpsilon(t, 15.0, spec.Loss.Percent, 1e-9)
+	require.NotNil(t, spec.Corrupt)
+	assert.InEpsilon(t, 5.0, spec.Corrupt.Percent, 1e-9)
+	assert.InEpsilon(t, 10.0, spec.Corrupt.Correlation, 1e-9)
+}
+
+func TestParseChain_SegmentKeepsSubcommandDefaults(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	rest, err := parseChain([]string{"delay", "rate", "mydb"}, spec)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mydb"}, rest)
+	// delay segment without flags gets the delay subcommand's own defaults
+	require.NotNil(t, spec.Delay)
+	assert.Equal(t, 100, spec.Delay.Time)
+	assert.Equal(t, 10, spec.Delay.Jitter)
+	assert.InEpsilon(t, 20.0, spec.Delay.Correlation, 1e-9)
+	// rate segment defaults to the rate subcommand's default rate
+	require.NotNil(t, spec.Rate)
+	assert.Equal(t, "100kbit", spec.Rate.Rate)
+}
+
+func TestParseChain_NoEffectKeyword(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	rest, err := parseChain([]string{"mydb", "other"}, spec)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mydb", "other"}, rest)
+	assert.Equal(t, netem.EffectsSpec{}, *spec)
+}
+
+func TestParseChain_AllArgsConsumed(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	rest, err := parseChain([]string{"loss", "--percent", "20"}, spec)
+	require.NoError(t, err)
+	assert.Empty(t, rest, "no leftover args means label / match-all targeting")
+	require.NotNil(t, spec.Loss)
+}
+
+func TestParseChain_DuplicateEffectRejected(t *testing.T) {
+	spec := &netem.EffectsSpec{Loss: &netem.LossSpec{Percent: 10}}
+	_, err := parseChain([]string{"loss", "--percent", "20", "mydb"}, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate netem effect "loss"`)
+}
+
+func TestParseChain_LossModelsNotChainable(t *testing.T) {
+	for _, name := range []string{"loss-state", "loss-gemodel"} {
+		spec := &netem.EffectsSpec{}
+		_, err := parseChain([]string{name, "--p13", "10", "mydb"}, spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be chained")
+	}
+}
+
+func TestParseChain_BadFlagNamesSegment(t *testing.T) {
+	spec := &netem.EffectsSpec{}
+	_, err := parseChain([]string{"loss", "--bogus", "20", "mydb"}, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `chained netem effect "loss"`)
+}
+
+func TestChainSpec_NoChainReturnsNotFound(t *testing.T) {
+	c := effectCtx(t, delayFlags(), []string{"--time", "200", "mydb"})
+	gp := &chaos.GlobalParams{Names: []string{"mydb"}}
+	_, found, err := chainSpec(c, gp, applyDelay)
+	require.NoError(t, err)
+	assert.False(t, found, "single-effect invocation must use the original code path")
+	assert.Equal(t, []string{"mydb"}, gp.Names, "gp untouched without a chain")
+}
+
+func TestChainSpec_ChainCombinesPrimaryAndSegments(t *testing.T) {
+	c := effectCtx(t, delayFlags(), []string{"--time", "200", "loss", "--percent", "15", "mydb"})
+	// NewAction parsed names from raw args — chainSpec must fix them up
+	gp := &chaos.GlobalParams{Names: []string{"loss", "--percent", "15", "mydb"}}
+	spec, found, err := chainSpec(c, gp, applyDelay)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, spec.Delay)
+	assert.Equal(t, 200, spec.Delay.Time)
+	require.NotNil(t, spec.Loss)
+	assert.InEpsilon(t, 15.0, spec.Loss.Percent, 1e-9)
+	assert.Equal(t, []string{"mydb"}, gp.Names, "targets re-derived from leftover args")
+	assert.Empty(t, gp.Pattern)
+}
+
+func TestChainSpec_Re2PatternLeftover(t *testing.T) {
+	c := effectCtx(t, lossFlags(), []string{"--percent", "10", "corrupt", "--percent", "5", "re2:^db"})
+	gp := &chaos.GlobalParams{}
+	_, found, err := chainSpec(c, gp, applyLoss)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, gp.Names)
+	assert.Equal(t, "^db", gp.Pattern)
+}
+
+func TestChainSpec_DuplicateOfPrimaryRejected(t *testing.T) {
+	c := effectCtx(t, lossFlags(), []string{"--percent", "10", "loss", "--percent", "20", "mydb"})
+	gp := &chaos.GlobalParams{}
+	_, _, err := chainSpec(c, gp, applyLoss)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate netem effect "loss"`)
+}

--- a/pkg/chaos/netem/cmd/corrupt.go
+++ b/pkg/chaos/netem/cmd/corrupt.go
@@ -19,24 +19,31 @@ type CorruptParams struct {
 	Limit       int
 	Percent     float64
 	Correlation float64
+	Chain       *netem.EffectsSpec // set when additional effects are chained after this one
+}
+
+// corruptFlags returns the corrupt subcommand's flag definitions; shared with
+// the effect-chaining registry so chained segments parse identically.
+func corruptFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.Float64Flag{
+			Name:  "percent, p",
+			Usage: "packet corrupt percentage",
+			Value: 0.0,
+		},
+		cli.Float64Flag{
+			Name:  "correlation, c",
+			Usage: "corrupt correlation; in percentage",
+			Value: 0.0,
+		},
+	}
 }
 
 // NewCorruptCLICommand initialize CLI corrupt command.
 func NewCorruptCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
 	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[CorruptParams]{
-		Name: "corrupt",
-		Flags: []cli.Flag{
-			cli.Float64Flag{
-				Name:  "percent, p",
-				Usage: "packet corrupt percentage",
-				Value: 0.0,
-			},
-			cli.Float64Flag{
-				Name:  "correlation, c",
-				Usage: "corrupt correlation; in percentage",
-				Value: 0.0,
-			},
-		},
+		Name:        "corrupt",
+		Flags:       corruptFlags(),
 		Usage:       "adds packet corruption",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", chaos.Re2Prefix),
 		Description: "adds packet corruption, based on independent (Bernoulli) probability model\n \tsee:  http://www.voiptroubleshooter.com/indepth/burstloss.html",
@@ -50,14 +57,25 @@ func parseCorruptParams(c cliflags.Flags, gp *chaos.GlobalParams) (CorruptParams
 	if err != nil {
 		return CorruptParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
 	}
-	return CorruptParams{
+	chain, chained, err := chainSpec(c, gp, applyCorrupt)
+	if err != nil {
+		return CorruptParams{}, err
+	}
+	params := CorruptParams{
 		Base:        base,
 		Limit:       limit,
 		Percent:     c.Float64("percent"),
 		Correlation: c.Float64("correlation"),
-	}, nil
+	}
+	if chained {
+		params.Chain = &chain
+	}
+	return params, nil
 }
 
 func buildCorruptCommand(client container.Client, gp *chaos.GlobalParams, p CorruptParams) (chaos.Command, error) {
+	if p.Chain != nil {
+		return netem.NewEffectsCommand(client, gp, p.Base, p.Limit, *p.Chain)
+	}
 	return netem.NewCorruptCommand(client, gp, p.Base, p.Limit, p.Percent, p.Correlation)
 }

--- a/pkg/chaos/netem/cmd/delay.go
+++ b/pkg/chaos/netem/cmd/delay.go
@@ -21,34 +21,41 @@ type DelayParams struct {
 	Jitter       int
 	Correlation  float64
 	Distribution string
+	Chain        *netem.EffectsSpec // set when additional effects are chained after this one
+}
+
+// delayFlags returns the delay subcommand's flag definitions; shared with the
+// effect-chaining registry so chained segments parse identically.
+func delayFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.IntFlag{
+			Name:  "time, t",
+			Usage: "delay time; in milliseconds",
+			Value: 100, //nolint:mnd
+		},
+		cli.IntFlag{
+			Name:  "jitter, j",
+			Usage: "random delay variation (jitter); in milliseconds; example: 100ms ± 10ms",
+			Value: 10, //nolint:mnd
+		},
+		cli.Float64Flag{
+			Name:  "correlation, c",
+			Usage: "delay correlation; in percentage",
+			Value: 20, //nolint:mnd
+		},
+		cli.StringFlag{
+			Name:  "distribution, d",
+			Usage: "delay distribution, can be one of {<empty> | uniform | normal | pareto |  paretonormal}",
+			Value: "",
+		},
+	}
 }
 
 // NewDelayCLICommand initialize CLI delay command.
 func NewDelayCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
 	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[DelayParams]{
-		Name: "delay",
-		Flags: []cli.Flag{
-			cli.IntFlag{
-				Name:  "time, t",
-				Usage: "delay time; in milliseconds",
-				Value: 100, //nolint:mnd
-			},
-			cli.IntFlag{
-				Name:  "jitter, j",
-				Usage: "random delay variation (jitter); in milliseconds; example: 100ms ± 10ms",
-				Value: 10, //nolint:mnd
-			},
-			cli.Float64Flag{
-				Name:  "correlation, c",
-				Usage: "delay correlation; in percentage",
-				Value: 20, //nolint:mnd
-			},
-			cli.StringFlag{
-				Name:  "distribution, d",
-				Usage: "delay distribution, can be one of {<empty> | uniform | normal | pareto |  paretonormal}",
-				Value: "",
-			},
-		},
+		Name:        "delay",
+		Flags:       delayFlags(),
 		Usage:       "delay egress traffic",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", chaos.Re2Prefix),
 		Description: "delay egress traffic for specified containers; networks show variability so it is possible to add random variation; delay variation isn't purely random, so to emulate that there is a correlation",
@@ -62,16 +69,27 @@ func parseDelayParams(c cliflags.Flags, gp *chaos.GlobalParams) (DelayParams, er
 	if err != nil {
 		return DelayParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
 	}
-	return DelayParams{
+	chain, chained, err := chainSpec(c, gp, applyDelay)
+	if err != nil {
+		return DelayParams{}, err
+	}
+	params := DelayParams{
 		Base:         base,
 		Limit:        limit,
 		Time:         c.Int("time"),
 		Jitter:       c.Int("jitter"),
 		Correlation:  c.Float64("correlation"),
 		Distribution: c.String("distribution"),
-	}, nil
+	}
+	if chained {
+		params.Chain = &chain
+	}
+	return params, nil
 }
 
 func buildDelayCommand(client container.Client, gp *chaos.GlobalParams, p DelayParams) (chaos.Command, error) {
+	if p.Chain != nil {
+		return netem.NewEffectsCommand(client, gp, p.Base, p.Limit, *p.Chain)
+	}
 	return netem.NewDelayCommand(client, gp, p.Base, p.Limit, p.Time, p.Jitter, p.Correlation, p.Distribution)
 }

--- a/pkg/chaos/netem/cmd/duplicate.go
+++ b/pkg/chaos/netem/cmd/duplicate.go
@@ -19,24 +19,31 @@ type DuplicateParams struct {
 	Limit       int
 	Percent     float64
 	Correlation float64
+	Chain       *netem.EffectsSpec // set when additional effects are chained after this one
+}
+
+// duplicateFlags returns the duplicate subcommand's flag definitions; shared
+// with the effect-chaining registry so chained segments parse identically.
+func duplicateFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.Float64Flag{
+			Name:  "percent, p",
+			Usage: "packet duplicate percentage",
+			Value: 0.0,
+		},
+		cli.Float64Flag{
+			Name:  "correlation, c",
+			Usage: "duplicate correlation; in percentage",
+			Value: 0.0,
+		},
+	}
 }
 
 // NewDuplicateCLICommand initialize CLI duplicate command.
 func NewDuplicateCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
 	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[DuplicateParams]{
-		Name: "duplicate",
-		Flags: []cli.Flag{
-			cli.Float64Flag{
-				Name:  "percent, p",
-				Usage: "packet duplicate percentage",
-				Value: 0.0,
-			},
-			cli.Float64Flag{
-				Name:  "correlation, c",
-				Usage: "duplicate correlation; in percentage",
-				Value: 0.0,
-			},
-		},
+		Name:        "duplicate",
+		Flags:       duplicateFlags(),
 		Usage:       "adds packet duplication",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", chaos.Re2Prefix),
 		Description: "adds packet duplication, based on independent (Bernoulli) probability model\n \tsee:  http://www.voiptroubleshooter.com/indepth/burstloss.html",
@@ -50,14 +57,25 @@ func parseDuplicateParams(c cliflags.Flags, gp *chaos.GlobalParams) (DuplicatePa
 	if err != nil {
 		return DuplicateParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
 	}
-	return DuplicateParams{
+	chain, chained, err := chainSpec(c, gp, applyDuplicate)
+	if err != nil {
+		return DuplicateParams{}, err
+	}
+	params := DuplicateParams{
 		Base:        base,
 		Limit:       limit,
 		Percent:     c.Float64("percent"),
 		Correlation: c.Float64("correlation"),
-	}, nil
+	}
+	if chained {
+		params.Chain = &chain
+	}
+	return params, nil
 }
 
 func buildDuplicateCommand(client container.Client, gp *chaos.GlobalParams, p DuplicateParams) (chaos.Command, error) {
+	if p.Chain != nil {
+		return netem.NewEffectsCommand(client, gp, p.Base, p.Limit, *p.Chain)
+	}
 	return netem.NewDuplicateCommand(client, gp, p.Base, p.Limit, p.Percent, p.Correlation)
 }

--- a/pkg/chaos/netem/cmd/loss.go
+++ b/pkg/chaos/netem/cmd/loss.go
@@ -19,24 +19,31 @@ type LossParams struct {
 	Limit       int
 	Percent     float64
 	Correlation float64
+	Chain       *netem.EffectsSpec // set when additional effects are chained after this one
+}
+
+// lossFlags returns the loss subcommand's flag definitions; shared with the
+// effect-chaining registry so chained segments parse identically.
+func lossFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.Float64Flag{
+			Name:  "percent, p",
+			Usage: "packet loss percentage",
+			Value: 0.0,
+		},
+		cli.Float64Flag{
+			Name:  "correlation, c",
+			Usage: "loss correlation; in percentage",
+			Value: 0.0,
+		},
+	}
 }
 
 // NewLossCLICommand initialize CLI loss command.
 func NewLossCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
 	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[LossParams]{
-		Name: "loss",
-		Flags: []cli.Flag{
-			cli.Float64Flag{
-				Name:  "percent, p",
-				Usage: "packet loss percentage",
-				Value: 0.0,
-			},
-			cli.Float64Flag{
-				Name:  "correlation, c",
-				Usage: "loss correlation; in percentage",
-				Value: 0.0,
-			},
-		},
+		Name:        "loss",
+		Flags:       lossFlags(),
 		Usage:       "adds packet losses",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", chaos.Re2Prefix),
 		Description: "adds packet losses, based on independent (Bernoulli) probability model\n \tsee:  http://www.voiptroubleshooter.com/indepth/burstloss.html",
@@ -50,14 +57,25 @@ func parseLossParams(c cliflags.Flags, gp *chaos.GlobalParams) (LossParams, erro
 	if err != nil {
 		return LossParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
 	}
-	return LossParams{
+	chain, chained, err := chainSpec(c, gp, applyLoss)
+	if err != nil {
+		return LossParams{}, err
+	}
+	params := LossParams{
 		Base:        base,
 		Limit:       limit,
 		Percent:     c.Float64("percent"),
 		Correlation: c.Float64("correlation"),
-	}, nil
+	}
+	if chained {
+		params.Chain = &chain
+	}
+	return params, nil
 }
 
 func buildLossCommand(client container.Client, gp *chaos.GlobalParams, p LossParams) (chaos.Command, error) {
+	if p.Chain != nil {
+		return netem.NewEffectsCommand(client, gp, p.Base, p.Limit, *p.Chain)
+	}
 	return netem.NewLossCommand(client, gp, p.Base, p.Limit, p.Percent, p.Correlation)
 }

--- a/pkg/chaos/netem/cmd/loss_ge.go
+++ b/pkg/chaos/netem/cmd/loss_ge.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Generic NewAction[P] enforces a uniform per-command shape; the residual similarity is intentional, not copy-paste.
 package cmd
 
 import (

--- a/pkg/chaos/netem/cmd/rate.go
+++ b/pkg/chaos/netem/cmd/rate.go
@@ -21,34 +21,41 @@ type RateParams struct {
 	PacketOverhead int
 	CellSize       int
 	CellOverhead   int
+	Chain          *netem.EffectsSpec // set when additional effects are chained after this one
+}
+
+// rateFlags returns the rate subcommand's flag definitions; shared with the
+// effect-chaining registry so chained segments parse identically.
+func rateFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  "rate, r",
+			Usage: "delay outgoing packets; in common units",
+			Value: "100kbit",
+		},
+		cli.IntFlag{
+			Name:  "packetoverhead, p",
+			Usage: "per packet overhead; in bytes",
+			Value: 0,
+		},
+		cli.IntFlag{
+			Name:  "cellsize, s",
+			Usage: "cell size of the simulated link layer scheme",
+			Value: 0,
+		},
+		cli.IntFlag{
+			Name:  "celloverhead, c",
+			Usage: "per cell overhead; in bytes",
+			Value: 0,
+		},
+	}
 }
 
 // NewRateCLICommand initialize CLI rate command.
 func NewRateCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
 	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[RateParams]{
-		Name: "rate",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "rate, r",
-				Usage: "delay outgoing packets; in common units",
-				Value: "100kbit",
-			},
-			cli.IntFlag{
-				Name:  "packetoverhead, p",
-				Usage: "per packet overhead; in bytes",
-				Value: 0,
-			},
-			cli.IntFlag{
-				Name:  "cellsize, s",
-				Usage: "cell size of the simulated link layer scheme",
-				Value: 0,
-			},
-			cli.IntFlag{
-				Name:  "celloverhead, c",
-				Usage: "per cell overhead; in bytes",
-				Value: 0,
-			},
-		},
+		Name:        "rate",
+		Flags:       rateFlags(),
 		Usage:       "rate limit egress traffic",
 		ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", chaos.Re2Prefix),
 		Description: "rate limit egress traffic for specified containers",
@@ -62,16 +69,27 @@ func parseRateParams(c cliflags.Flags, gp *chaos.GlobalParams) (RateParams, erro
 	if err != nil {
 		return RateParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
 	}
-	return RateParams{
+	chain, chained, err := chainSpec(c, gp, applyRate)
+	if err != nil {
+		return RateParams{}, err
+	}
+	params := RateParams{
 		Base:           base,
 		Limit:          limit,
 		Rate:           c.String("rate"),
 		PacketOverhead: c.Int("packetoverhead"),
 		CellSize:       c.Int("cellsize"),
 		CellOverhead:   c.Int("celloverhead"),
-	}, nil
+	}
+	if chained {
+		params.Chain = &chain
+	}
+	return params, nil
 }
 
 func buildRateCommand(client container.Client, gp *chaos.GlobalParams, p RateParams) (chaos.Command, error) {
+	if p.Chain != nil {
+		return netem.NewEffectsCommand(client, gp, p.Base, p.Limit, *p.Chain)
+	}
 	return netem.NewRateCommand(client, gp, p.Base, p.Limit, p.Rate, p.PacketOverhead, p.CellSize, p.CellOverhead)
 }

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -21,6 +21,28 @@ type corruptCommand struct {
 	correlation float64
 }
 
+// validateCorrupt checks netem corrupt parameters; shared by the corrupt and chained-effects commands.
+func validateCorrupt(percent, correlation float64) error {
+	// get netem corrupt percent
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid corrupt percent: must be between 0.0 and 100.0")
+	}
+	// get netem corrupt variation
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid corrupt correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+// corruptArgs builds the netem 'corrupt ...' argument list; shared by the corrupt and chained-effects commands.
+func corruptArgs(percent, correlation float64) []string {
+	cmd := []string{"corrupt", strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewCorruptCommand create new netem corrupt command
 func NewCorruptCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -29,13 +51,8 @@ func NewCorruptCommand(client netemClient,
 	percent, // corrupt percent
 	correlation float64, // corrupt correlation
 ) (chaos.Command, error) {
-	// get netem corrupt percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid corrupt percent: must be between 0.0 and 100.0")
-	}
-	// get netem corrupt variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid corrupt correlation: must be between 0.0 and 100.0")
+	if err := validateCorrupt(percent, correlation); err != nil {
+		return nil, err
 	}
 	return &corruptCommand{
 		client:      client,
@@ -77,9 +94,5 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *corruptCommand) buildNetemCmd() []string {
-	cmd := []string{"corrupt", strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return corruptArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -29,6 +29,42 @@ type delayCommand struct {
 	distribution string
 }
 
+// validateDelay checks netem delay parameters; shared by the delay and chained-effects commands.
+func validateDelay(delay, jitter int, correlation float64, distribution string) error {
+	// check delay time
+	if delay <= 0 {
+		return errors.New("non-positive delay time")
+	}
+	// get delay variation
+	if jitter < 0 || jitter > delay {
+		return errors.New("invalid delay jitter: must be non-negative and smaller than delay time")
+	}
+	// get delay variation
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid delay correlation: must be between 0.0 and 100.0")
+	}
+	// get distribution
+	if !slices.Contains(delayDistribution, distribution) {
+		return errors.New("invalid delay distribution: must be one of {uniform | normal | pareto |  paretonormal}")
+	}
+	return nil
+}
+
+// delayArgs builds the netem 'delay ...' argument list; shared by the delay and chained-effects commands.
+func delayArgs(delay, jitter int, correlation float64, distribution string) []string {
+	cmd := []string{"delay", strconv.Itoa(delay) + "ms"}
+	if jitter > 0 {
+		cmd = append(cmd, strconv.Itoa(jitter)+"ms")
+	}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	if distribution != "" {
+		cmd = append(cmd, "distribution", distribution)
+	}
+	return cmd
+}
+
 // NewDelayCommand create new netem delay command
 func NewDelayCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -39,21 +75,8 @@ func NewDelayCommand(client netemClient,
 	correlation float64, // delay correlation
 	distribution string, // delay distribution
 ) (chaos.Command, error) {
-	// check delay time
-	if delay <= 0 {
-		return nil, errors.New("non-positive delay time")
-	}
-	// get delay variation
-	if jitter < 0 || jitter > delay {
-		return nil, errors.New("invalid delay jitter: must be non-negative and smaller than delay time")
-	}
-	// get delay variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid delay correlation: must be between 0.0 and 100.0")
-	}
-	// get distribution
-	if !slices.Contains(delayDistribution, distribution) {
-		return nil, errors.New("invalid delay distribution: must be one of {uniform | normal | pareto |  paretonormal}")
+	if err := validateDelay(delay, jitter, correlation, distribution); err != nil {
+		return nil, err
 	}
 	return &delayCommand{
 		client:       client,
@@ -95,15 +118,5 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *delayCommand) buildNetemCmd() []string {
-	cmd := []string{"delay", strconv.Itoa(n.time) + "ms"}
-	if n.jitter > 0 {
-		cmd = append(cmd, strconv.Itoa(n.jitter)+"ms")
-	}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	if n.distribution != "" {
-		cmd = append(cmd, []string{"distribution", n.distribution}...)
-	}
-	return cmd
+	return delayArgs(n.time, n.jitter, n.correlation, n.distribution)
 }

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -25,6 +25,28 @@ type duplicateCommand struct {
 	correlation float64
 }
 
+// validateDuplicate checks netem duplicate parameters; shared by the duplicate and chained-effects commands.
+func validateDuplicate(percent, correlation float64) error {
+	// get netem duplicate percent
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid duplicate percent: must be between 0.0 and 100.0")
+	}
+	// get netem duplicate variation
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid duplicate correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+// duplicateArgs builds the netem 'duplicate ...' argument list; shared by the duplicate and chained-effects commands.
+func duplicateArgs(percent, correlation float64) []string {
+	cmd := []string{duplicateCmd, strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewDuplicateCommand create new netem duplicate command
 func NewDuplicateCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -33,13 +55,8 @@ func NewDuplicateCommand(client netemClient,
 	percent, // duplicate percent
 	correlation float64, // duplicate correlation
 ) (chaos.Command, error) {
-	// get netem duplicate percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid duplicate percent: must be between 0.0 and 100.0")
-	}
-	// get netem duplicate variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid duplicate correlation: must be between 0.0 and 100.0")
+	if err := validateDuplicate(percent, correlation); err != nil {
+		return nil, err
 	}
 	return &duplicateCommand{
 		client:      client,
@@ -81,9 +98,5 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *duplicateCommand) buildNetemCmd() []string {
-	cmd := []string{duplicateCmd, strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return duplicateArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/effects.go
+++ b/pkg/chaos/netem/effects.go
@@ -1,0 +1,174 @@
+package netem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/container"
+	log "github.com/sirupsen/logrus"
+)
+
+// DelaySpec holds netem delay parameters for chained netem effects.
+type DelaySpec struct {
+	Time         int
+	Jitter       int
+	Correlation  float64
+	Distribution string
+}
+
+// LossSpec holds netem random loss parameters for chained netem effects.
+type LossSpec struct {
+	Percent     float64
+	Correlation float64
+}
+
+// CorruptSpec holds netem corrupt parameters for chained netem effects.
+type CorruptSpec struct {
+	Percent     float64
+	Correlation float64
+}
+
+// DuplicateSpec holds netem duplicate parameters for chained netem effects.
+type DuplicateSpec struct {
+	Percent     float64
+	Correlation float64
+}
+
+// RateSpec holds netem rate parameters for chained netem effects.
+type RateSpec struct {
+	Rate           string
+	PacketOverhead int
+	CellSize       int
+	CellOverhead   int
+}
+
+// EffectsSpec selects which netem effects to combine into a single qdisc.
+// A nil field means the effect is disabled; at least one must be set.
+type EffectsSpec struct {
+	Delay     *DelaySpec
+	Loss      *LossSpec
+	Corrupt   *CorruptSpec
+	Duplicate *DuplicateSpec
+	Rate      *RateSpec
+}
+
+// validate checks every enabled effect using the same rules as the
+// corresponding single-effect command.
+func (s EffectsSpec) validate() error {
+	checks := s.effectChecks()
+	if len(checks) == 0 {
+		return errors.New("at least one netem effect required: delay, loss, corrupt, duplicate or rate")
+	}
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// effectChecks returns one validation closure per enabled effect.
+func (s EffectsSpec) effectChecks() []func() error {
+	var checks []func() error
+	if s.Delay != nil {
+		checks = append(checks, func() error {
+			return validateDelay(s.Delay.Time, s.Delay.Jitter, s.Delay.Correlation, s.Delay.Distribution)
+		})
+	}
+	if s.Loss != nil {
+		checks = append(checks, func() error { return validateLoss(s.Loss.Percent, s.Loss.Correlation) })
+	}
+	if s.Corrupt != nil {
+		checks = append(checks, func() error { return validateCorrupt(s.Corrupt.Percent, s.Corrupt.Correlation) })
+	}
+	if s.Duplicate != nil {
+		checks = append(checks, func() error { return validateDuplicate(s.Duplicate.Percent, s.Duplicate.Correlation) })
+	}
+	if s.Rate != nil {
+		checks = append(checks, func() error { return validateRateParams(s.Rate.Rate, s.Rate.CellSize) })
+	}
+	return checks
+}
+
+// args concatenates the enabled effects into a single netem argument list,
+// e.g. 'delay 100ms 10ms loss 20.00 corrupt 5.00'.
+func (s EffectsSpec) args() []string {
+	var cmd []string
+	if s.Delay != nil {
+		cmd = append(cmd, delayArgs(s.Delay.Time, s.Delay.Jitter, s.Delay.Correlation, s.Delay.Distribution)...)
+	}
+	if s.Loss != nil {
+		cmd = append(cmd, lossArgs(s.Loss.Percent, s.Loss.Correlation)...)
+	}
+	if s.Duplicate != nil {
+		cmd = append(cmd, duplicateArgs(s.Duplicate.Percent, s.Duplicate.Correlation)...)
+	}
+	if s.Corrupt != nil {
+		cmd = append(cmd, corruptArgs(s.Corrupt.Percent, s.Corrupt.Correlation)...)
+	}
+	if s.Rate != nil {
+		cmd = append(cmd, rateArgs(s.Rate.Rate, s.Rate.PacketOverhead, s.Rate.CellSize, s.Rate.CellOverhead)...)
+	}
+	return cmd
+}
+
+// chained netem effects command
+type effectsCommand struct {
+	client netemClient
+	gp     *chaos.GlobalParams
+	req    *container.NetemRequest
+	limit  int
+	spec   EffectsSpec
+}
+
+// NewEffectsCommand create new netem effects command combining multiple netem
+// effects (delay, loss, duplicate, corrupt, rate) in a single qdisc
+func NewEffectsCommand(client netemClient,
+	gp *chaos.GlobalParams,
+	req *container.NetemRequest,
+	limit int,
+	spec EffectsSpec, // enabled netem effects
+) (chaos.Command, error) {
+	if err := spec.validate(); err != nil {
+		return nil, err
+	}
+	return &effectsCommand{
+		client: client,
+		gp:     gp,
+		req:    req,
+		limit:  limit,
+		spec:   spec,
+	}, nil
+}
+
+// Run chained netem effects
+func (n *effectsCommand) Run(ctx context.Context, random bool) error {
+	log.Debug("adding combined network effects to all matching containers")
+	log.WithFields(log.Fields{
+		"names":   n.gp.Names,
+		"pattern": n.gp.Pattern,
+		"labels":  n.gp.Labels,
+		"limit":   n.limit,
+		"random":  random,
+	}).Debug("listing matching containers")
+	netemCmd := n.spec.args()
+	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
+		func(ctx context.Context, c *container.Container) error {
+			log.WithFields(log.Fields{
+				"container": c,
+				"command":   netemCmd,
+			}).Debug("adding combined network effects for container")
+			netemCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			req := *n.req
+			req.Container = c
+			req.Command = netemCmd
+			if err := runNetem(netemCtx, n.client, &req); err != nil {
+				log.WithError(err).Warn("failed to add combined network effects for container")
+				return fmt.Errorf("failed to add combined network effects for one or more containers: %w", err)
+			}
+			return nil
+		})
+}

--- a/pkg/chaos/netem/effects_test.go
+++ b/pkg/chaos/netem/effects_test.go
@@ -1,0 +1,211 @@
+package netem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEffectsCommand_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    EffectsSpec
+		wantErr string
+	}{
+		{
+			name:    "no effects rejected",
+			spec:    EffectsSpec{},
+			wantErr: "at least one netem effect required",
+		},
+		{
+			name: "valid single effect",
+			spec: EffectsSpec{Delay: &DelaySpec{Time: 100}},
+		},
+		{
+			name: "valid all effects",
+			spec: EffectsSpec{
+				Delay:     &DelaySpec{Time: 100, Jitter: 10, Correlation: 25.0, Distribution: "normal"},
+				Loss:      &LossSpec{Percent: 20.0, Correlation: 10.0},
+				Corrupt:   &CorruptSpec{Percent: 5.0},
+				Duplicate: &DuplicateSpec{Percent: 3.0},
+				Rate:      &RateSpec{Rate: "100kbit"},
+			},
+		},
+		{
+			name:    "invalid delay propagated",
+			spec:    EffectsSpec{Delay: &DelaySpec{Time: 100, Jitter: 200}},
+			wantErr: "invalid delay jitter",
+		},
+		{
+			name:    "invalid delay distribution propagated",
+			spec:    EffectsSpec{Delay: &DelaySpec{Time: 100, Distribution: "gaussian"}},
+			wantErr: "invalid delay distribution",
+		},
+		{
+			name:    "invalid loss propagated",
+			spec:    EffectsSpec{Loss: &LossSpec{Percent: 101.0}},
+			wantErr: "invalid loss percent",
+		},
+		{
+			name:    "invalid corrupt propagated",
+			spec:    EffectsSpec{Corrupt: &CorruptSpec{Percent: 5.0, Correlation: 101.0}},
+			wantErr: "invalid corrupt correlation",
+		},
+		{
+			name:    "invalid duplicate propagated",
+			spec:    EffectsSpec{Duplicate: &DuplicateSpec{Percent: -1.0}},
+			wantErr: "invalid duplicate percent",
+		},
+		{
+			name:    "invalid rate propagated",
+			spec:    EffectsSpec{Rate: &RateSpec{Rate: "notarate"}},
+			wantErr: "invalid rate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, gParams, nParams := validationFixtures(t)
+			cmd, err := NewEffectsCommand(client, gParams, nParams, 0, tt.spec)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, cmd)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, cmd)
+			}
+		})
+	}
+}
+
+func TestEffectsCommand_Run_NoContainers(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	gparams := &chaos.GlobalParams{Names: []string{"nonexistent"}}
+	nparams := &container.NetemRequest{Interface: "eth0", Duration: time.Second}
+
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"),
+		container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{}, nil)
+
+	cmd, err := NewEffectsCommand(mockClient, gparams, nparams, 0, EffectsSpec{Delay: &DelaySpec{Time: 100}})
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), false)
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+func TestEffectsCommand_Run_WithRandom(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c1 := &container.Container{ContainerID: "id1", ContainerName: "c1"}
+	c2 := &container.Container{ContainerID: "id2", ContainerName: "c2"}
+
+	gparams := &chaos.GlobalParams{Names: []string{"c1", "c2"}, DryRun: true}
+	nparams := &container.NetemRequest{
+		Interface: "eth0",
+		Duration:  100 * time.Millisecond,
+		Sidecar:   container.SidecarSpec{Image: "tc"},
+		DryRun:    true,
+	}
+
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"),
+		container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{c1, c2}, nil)
+
+	mockClient.EXPECT().NetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Once()
+	mockClient.EXPECT().StopNetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Once()
+
+	cmd, err := NewEffectsCommand(mockClient, gparams, nparams, 0,
+		EffectsSpec{Delay: &DelaySpec{Time: 100}, Loss: &LossSpec{Percent: 20.0}})
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), true)
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+func TestEffectsCommand_Run_DryRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     EffectsSpec
+		netemCmd []string
+	}{
+		{
+			name: "delay with loss and corrupt",
+			spec: EffectsSpec{
+				Delay:   &DelaySpec{Time: 100, Jitter: 10},
+				Loss:    &LossSpec{Percent: 20.0},
+				Corrupt: &CorruptSpec{Percent: 5.0},
+			},
+			netemCmd: []string{"delay", "100ms", "10ms", "loss", "20.00", "corrupt", "5.00"},
+		},
+		{
+			name: "all effects fixed order",
+			spec: EffectsSpec{
+				Delay:     &DelaySpec{Time: 200, Jitter: 50, Correlation: 25.5, Distribution: "normal"},
+				Loss:      &LossSpec{Percent: 10.0, Correlation: 5.0},
+				Duplicate: &DuplicateSpec{Percent: 3.0},
+				Corrupt:   &CorruptSpec{Percent: 1.0},
+				Rate:      &RateSpec{Rate: "100kbit"},
+			},
+			netemCmd: []string{
+				"delay", "200ms", "50ms", "25.50", "distribution", "normal",
+				"loss", "10.00", "5.00",
+				"duplicate", "3.00",
+				"corrupt", "1.00",
+				"rate", "100kbit",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := container.NewMockClient(t)
+			target := &container.Container{
+				ContainerID:   "abc123",
+				ContainerName: "target",
+				Labels:        map[string]string{},
+				Networks:      map[string]container.NetworkLink{},
+			}
+			gparams := &chaos.GlobalParams{Names: []string{"target"}, DryRun: true}
+			nparams := &container.NetemRequest{
+				Interface: "eth0",
+				Duration:  100 * time.Millisecond,
+				Sidecar:   container.SidecarSpec{Image: "tc"},
+				DryRun:    true,
+			}
+
+			mockClient.EXPECT().ListContainers(mock.Anything,
+				mock.AnythingOfType("container.FilterFunc"),
+				container.ListOpts{All: false, Labels: nil}).
+				Return([]*container.Container{target}, nil)
+
+			expectedReq := &container.NetemRequest{
+				Container: target,
+				Interface: "eth0",
+				Command:   tt.netemCmd,
+				Duration:  100 * time.Millisecond,
+				Sidecar:   container.SidecarSpec{Image: "tc"},
+				DryRun:    true,
+			}
+			mockClient.EXPECT().NetemContainer(mock.Anything, expectedReq).Return(nil)
+			mockClient.EXPECT().StopNetemContainer(mock.Anything, expectedReq).Return(nil)
+
+			cmd, err := NewEffectsCommand(mockClient, gparams, nparams, 0, tt.spec)
+			require.NoError(t, err)
+
+			err = cmd.Run(context.Background(), false)
+			assert.NoError(t, err)
+			mockClient.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -21,6 +21,28 @@ type lossCommand struct {
 	correlation float64
 }
 
+// validateLoss checks netem loss parameters; shared by the loss and chained-effects commands.
+func validateLoss(percent, correlation float64) error {
+	// get netem loss percent
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid loss percent: must be between 0.0 and 100.0")
+	}
+	// get netem loss variation
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid loss correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+// lossArgs builds the netem 'loss ...' argument list; shared by the loss and chained-effects commands.
+func lossArgs(percent, correlation float64) []string {
+	cmd := []string{"loss", strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewLossCommand create new netem loss command
 func NewLossCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -29,13 +51,8 @@ func NewLossCommand(client netemClient,
 	percent, // loss percent
 	correlation float64, // loss correlation
 ) (chaos.Command, error) {
-	// get netem loss percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid loss percent: must be between 0.0 and 100.0")
-	}
-	// get netem loss variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid loss correlation: must be between 0.0 and 100.0")
+	if err := validateLoss(percent, correlation); err != nil {
+		return nil, err
 	}
 
 	return &lossCommand{
@@ -76,9 +93,5 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *lossCommand) buildNetemCmd() []string {
-	cmd := []string{"loss", strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return lossArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -34,6 +34,38 @@ type rateCommand struct {
 	cellOverhead   int
 }
 
+// validateRateParams checks netem rate parameters; shared by the rate and chained-effects commands.
+func validateRateParams(rate string, cellSize int) error {
+	// validate target egress rate
+	if rate == "" {
+		return errors.New("undefined rate limit")
+	}
+	if _, err := parseRate(rate); err != nil {
+		return fmt.Errorf("invalid rate: %w", err)
+	}
+
+	// validate cell size
+	if cellSize < 0 {
+		return errors.New("invalid cell size: must be a non-negative integer")
+	}
+	return nil
+}
+
+// rateArgs builds the netem 'rate ...' argument list; shared by the rate and chained-effects commands.
+func rateArgs(rate string, packetOverhead, cellSize, cellOverhead int) []string {
+	cmd := []string{"rate", rate}
+	if packetOverhead != 0 {
+		cmd = append(cmd, strconv.Itoa(packetOverhead))
+	}
+	if cellSize > 0 {
+		cmd = append(cmd, strconv.Itoa(cellSize))
+	}
+	if cellOverhead != 0 {
+		cmd = append(cmd, strconv.Itoa(cellOverhead))
+	}
+	return cmd
+}
+
 // NewRateCommand create new netem rate command
 func NewRateCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -44,18 +76,8 @@ func NewRateCommand(client netemClient,
 	cellSize, // cell size of the simulated link layer scheme
 	cellOverhead int, // per cell overhead; in bytes
 ) (chaos.Command, error) {
-	// validate target egress rate
-	if rate == "" {
-		return nil, errors.New("undefined rate limit")
-	}
-	rate, err := parseRate(rate)
-	if err != nil {
-		return nil, fmt.Errorf("invalid rate: %w", err)
-	}
-
-	// validate cell size
-	if cellSize < 0 {
-		return nil, errors.New("invalid cell size: must be a non-negative integer")
+	if err := validateRateParams(rate, cellSize); err != nil {
+		return nil, err
 	}
 
 	return &rateCommand{
@@ -101,15 +123,5 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *rateCommand) buildNetemCmd() []string {
-	cmd := []string{"rate", n.rate}
-	if n.packetOverhead != 0 {
-		cmd = append(cmd, strconv.Itoa(n.packetOverhead))
-	}
-	if n.cellSize > 0 {
-		cmd = append(cmd, strconv.Itoa(n.cellSize))
-	}
-	if n.cellOverhead != 0 {
-		cmd = append(cmd, strconv.Itoa(n.cellOverhead))
-	}
-	return cmd
+	return rateArgs(n.rate, n.packetOverhead, n.cellSize, n.cellOverhead)
 }

--- a/tests/netem.bats
+++ b/tests/netem.bats
@@ -215,6 +215,43 @@ teardown() {
     assert_sidecar_cleaned
 }
 
+@test "Should apply chained netem effects in a single qdisc" {
+    # Given a running container
+    create_test_container "pingtest" "alpine" "sleep infinity"
+    assert_container_running "pingtest"
+    ensure_nettools_image
+
+    # Chain delay + loss in one invocation: combined into a single netem qdisc
+    pumba netem --duration 10s --tc-image ${NETTOOLS_IMAGE} --pull-image=false delay --time 100 loss --percent 10 pingtest &
+    PUMBA_PID=$!
+
+    # Wait for netem to be applied
+    wait_for 5 "nsenter -t \$(docker inspect -f '{{.State.Pid}}' pingtest) -n tc qdisc show dev eth0 2>/dev/null | grep -qi netem" "netem to be applied"
+
+    # Verify a single netem qdisc carries both effects
+    local pid
+    pid=$(docker inspect -f '{{.State.Pid}}' pingtest)
+    run nsenter -t "$pid" -n tc qdisc show dev eth0
+    assert_output --partial "netem"
+    assert_output --partial "delay"
+    assert_output --partial "loss"
+
+    # Wait for pumba to finish and clean up
+    wait $PUMBA_PID
+    local pumba_exit=$?
+    [ $pumba_exit -eq 0 ]
+
+    # Verify cleanup
+    assert_netem_cleaned "pingtest"
+    assert_sidecar_cleaned
+}
+
+@test "Should fail when the same effect is chained twice" {
+    run pumba netem --duration 200ms delay --time 100 delay --time 50 pingtest
+    assert_failure
+    assert_output --partial 'duplicate netem effect "delay"'
+}
+
 @test "Should clean up sidecar containers after netem completes" {
     create_test_container "pingtest" "alpine" "sleep infinity"
     assert_container_running "pingtest"


### PR DESCRIPTION
## Motivation

Only one root netem qdisc can exist per network interface, so today it's impossible to apply
two netem effects to the same container: running `netem delay` and `netem loss` as separate
pumba processes makes the second `tc qdisc add` fail with
`RTNETLINK: Exclusivity flag on, cannot modify`.

tc itself supports combining effects in one qdisc (`tc qdisc add dev eth0 root netem delay
100ms loss 20%`) — pumba just had no way to express it.

## What

Netem subcommands can now be **chained** in a single invocation:

```bash
# 100ms delay (±10ms) AND 20% packet loss, in one qdisc
pumba netem --duration 5m delay --time 100 --jitter 10 loss --percent 20 mydb 

# full degradation: delay + loss + corruption + bandwidth cap
pumba netem --duration 10m delay --time 100 loss --percent 20 corrupt --percent 5 rate --rate 1mbit myapp
```

Every chained effect keeps its original subcommand name, flags, aliases, and defaults —
there is no new subcommand and no new flag namespace. Chainable: delay, loss, corrupt,
duplicate, rate.

## How

After urfave/cli parses the first effect's flags, the remaining positional args are scanned: a known effect keyword starts a new segment, parsed with that effect's own []cli.Flag definitions (including urfave's alias normalization); whatever remains is the container list / re2: pattern, as usual (pkg/chaos/netem/cmd/chain.go).
All effects compose into one EffectsSpec → one req.Command → one tc qdisc add … netem …. Runtime layers (docker/containerd/podman) are untouched.
Validation and netem-arg building are extracted into helpers shared between the single-effect and chained paths, so composed args are byte-identical to the individual commands.

## Semantics & edge cases

No chain → no change: single-effect invocations take the exact pre-existing code path (same constructors, same behavior, same logs).
The same effect twice in a chain → duplicate netem effect "delay" in chain.
loss-state / loss-gemodel cannot be chained (loss models are mutually exclusive on a single qdisc) → clear error.
Effect keywords take precedence over container names; a container literally named loss can be targeted with re2:^loss$. Documented in docs/network-chaos.md.

## Testing

Unit: chain scanner (segments, aliases, per-segment defaults, duplicate/not-chainable/bad-flag errors, re2: leftover) and the combined command (validation, NoContainers / DryRun / WithRandom, exact composed netem args). All existing tests pass unchanged.
Bats: chained delay --time 100 loss --percent 10 applied and cleaned up; duplicate-effect failure case.
Verified live against Docker: tc qdisc show inside the target netns reports qdisc netem … delay 100ms 10ms 20% loss 20% while active, and the qdisc is removed after --duration.
Footprint
Additive only — no deletions or behavior changes to existing code. New files: netem/effects.go,
netem/cmd/chain.go (+tests). Existing files get small hooks (flag lists extracted to shared
funcs, a chain step in each parser, one exported helper in pkg/chaos/command.go).

## Notes

I first implemented another solution using a 'combo' keyword to change less of the original CLI logic. This also worked, but was less compatible with the existing Pumba implementation. The combo implementation is this branch: https://github.com/hermanbr/pumba/tree/herman_add_multiple_tc_cmds .