### PR TITLE
fix: stop deleting the root prio qdisc when tearing down IP-scoped netem loss

### DIFF
--- a/pkg/runtime/containerd/client_test.go
+++ b/pkg/runtime/containerd/client_test.go
@@ -1568,7 +1568,7 @@ func TestBuildNetemCommands(t *testing.T) {
 			cmds:  []string{"delay", "100ms"},
 			ips:   func() []*net.IPNet { _, n, _ := net.ParseCIDR("10.0.0.0/8"); return []*net.IPNet{n} }(),
 			wantCmds: [][]string{
-				{"qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"},
+				{"qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:1", "handle", "10:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:2", "handle", "20:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:3", "handle", "30:", "netem", "delay", "100ms"},
@@ -1581,7 +1581,7 @@ func TestBuildNetemCommands(t *testing.T) {
 			cmds:   []string{"delay", "100ms"},
 			sports: []string{"80"},
 			wantCmds: [][]string{
-				{"qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"},
+				{"qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:1", "handle", "10:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:2", "handle", "20:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:3", "handle", "30:", "netem", "delay", "100ms"},
@@ -1594,7 +1594,7 @@ func TestBuildNetemCommands(t *testing.T) {
 			cmds:   []string{"delay", "100ms"},
 			dports: []string{"443"},
 			wantCmds: [][]string{
-				{"qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"},
+				{"qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:1", "handle", "10:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:2", "handle", "20:", "sfq"},
 				{"qdisc", "add", "dev", "eth0", "parent", "1:3", "handle", "30:", "netem", "delay", "100ms"},
@@ -1624,9 +1624,15 @@ func TestBuildStopNetemCommands(t *testing.T) {
 	t.Run("with_filters", func(t *testing.T) {
 		t.Parallel()
 		cmds := buildStopNetemCommands("eth0", true)
-		assert.Len(t, cmds, 4)
-		assert.Equal(t, []string{"qdisc", "del", "dev", "eth0", "parent", "1:1", "handle", "10:"}, cmds[0])
-		assert.Equal(t, []string{"qdisc", "del", "dev", "eth0", "root", "handle", "1:", "prio"}, cmds[3])
+		// The root prio qdisc is intentionally left in place - see the comment on
+		// buildStopNetemCommands - so only the classifier and the three per-band
+		// child qdiscs are removed.
+		assert.Equal(t, [][]string{
+			{"filter", "del", "dev", "eth0", "parent", "1:0"},
+			{"qdisc", "del", "dev", "eth0", "parent", "1:1", "handle", "10:"},
+			{"qdisc", "del", "dev", "eth0", "parent", "1:2", "handle", "20:"},
+			{"qdisc", "del", "dev", "eth0", "parent", "1:3", "handle", "30:"},
+		}, cmds)
 	})
 }
 

--- a/pkg/runtime/containerd/commands.go
+++ b/pkg/runtime/containerd/commands.go
@@ -29,7 +29,9 @@ func buildNetemCommands(netInterface string, netemCmd []string, ips []*net.IPNet
 	netemArgs = append(netemArgs, netemCmd...)
 
 	commands := [][]string{
-		{"qdisc", "add", "dev", netInterface, "root", "handle", "1:", "prio"},
+		// 'replace' (not 'add') so this is idempotent if a previous run's teardown
+		// left this same root qdisc in place - see buildStopNetemCommands.
+		{"qdisc", "replace", "dev", netInterface, "root", "handle", "1:", "prio"},
 		{"qdisc", "add", "dev", netInterface, "parent", "1:1", "handle", "10:", "sfq"},
 		{"qdisc", "add", "dev", netInterface, "parent", "1:2", "handle", "20:", "sfq"},
 		netemArgs,
@@ -58,16 +60,36 @@ func buildNetemCommands(netInterface string, netemCmd []string, ips []*net.IPNet
 }
 
 // buildStopNetemCommands constructs tc commands to remove network emulation.
-// When filters were used, removes the priority qdisc hierarchy; otherwise just deletes root netem.
+// When filters were used, removes the classifier and per-band qdiscs that made the
+// disruption IP/port-scoped; otherwise just deletes root netem.
+//
+// The root 'prio' qdisc is deliberately left in place in the filtered case: deleting
+// or replacing a ROOT qdisc routes through the kernel's qdisc_graft() parent==NULL
+// path (net/sched/sch_api.c), which wraps the swap in dev_deactivate()/dev_activate().
+// dev_deactivate() installs noop_qdisc on every tx queue of the device for the
+// duration of the swap, and noop_qdisc drops every packet handed to it - not just
+// packets that matched our u32 filter - because by that point the whole
+// prio+filter+netem tree that implemented the IP scoping has already been unlinked.
+// That is the actual cause of "all IPs lose traffic during teardown": deleting the
+// 'parent 1:1/1:2/1:3' child qdiscs above does NOT have this effect, because those
+// go through prio's classful cops->graft() (sch_prio.c), which atomically substitutes
+// a default pfifo qdisc under sch_tree_lock and never touches dev_queue->qdisc.
+// Deleting the filter first (before any qdisc teardown) also means matched traffic
+// falls back to the loss-free default bands 1:1/1:2 immediately, before anything else
+// happens. buildNetemCommands uses 'qdisc replace' for the root so a later netem run
+// on the same container remains idempotent against this intentionally-left-behind
+// qdisc.
 func buildStopNetemCommands(netInterface string, hasFilters bool) [][]string {
 	if !hasFilters {
 		return [][]string{{"qdisc", "del", "dev", netInterface, "root"}}
 	}
 	return [][]string{
+		// A filter delete without a specific handle removes every filter registered
+		// under that parent, which matches every filter buildNetemCommands ever adds.
+		{"filter", "del", "dev", netInterface, "parent", "1:0"},
 		{"qdisc", "del", "dev", netInterface, "parent", "1:1", "handle", "10:"},
 		{"qdisc", "del", "dev", netInterface, "parent", "1:2", "handle", "20:"},
 		{"qdisc", "del", "dev", netInterface, "parent", "1:3", "handle", "30:"},
-		{"qdisc", "del", "dev", netInterface, "root", "handle", "1:", "prio"},
 	}
 }
 

--- a/pkg/runtime/docker/netem.go
+++ b/pkg/runtime/docker/netem.go
@@ -82,6 +82,15 @@ func (client dockerClient) stopNetemContainer(ctx context.Context, req *ctr.Nete
 		var netemCommands [][]string
 		if len(req.IPs) != 0 || len(req.SPorts) != 0 || len(req.DPorts) != 0 {
 			netemCommands = [][]string{
+				// delete the u32 filter(s) that classify target traffic into band 1:3.
+				// 'tc filter del' only unlinks entries from the classifier list - it
+				// never touches dev_queue->qdisc - so this is safe and instantaneous:
+				// once it runs, target traffic falls back to the (still sfq-backed,
+				// loss-free) default bands 1:1/1:2 immediately.
+				// A filter delete without a specific handle removes every filter
+				// registered under that parent, which matches every filter this
+				// package ever adds (parent 1:0).
+				{"filter", "del", "dev", req.Interface, "parent", "1:0"},
 				// delete qdisc 'parent 1:1 handle 10:'
 				// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 				{"qdisc", "del", "dev", req.Interface, "parent", "1:1", "handle", "10:"},
@@ -91,9 +100,28 @@ func (client dockerClient) stopNetemContainer(ctx context.Context, req *ctr.Nete
 				// delete qdisc 'parent 1:3 handle 30:'
 				// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 				{"qdisc", "del", "dev", req.Interface, "parent", "1:3", "handle", "30:"},
-				// delete qdisc 'root handle 1: prio'
-				// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
-				{"qdisc", "del", "dev", req.Interface, "root", "handle", "1:", "prio"},
+				// Deliberately do NOT delete the root 'prio' qdisc (handle 1:) here.
+				//
+				// Replacing/deleting a ROOT qdisc forces the kernel through
+				// qdisc_graft()'s parent==NULL path (net/sched/sch_api.c), which calls
+				// dev_deactivate() before grafting the new/default qdisc and
+				// dev_activate() after. dev_deactivate() installs noop_qdisc on every
+				// tx queue of the device while the swap happens, and noop_qdisc drops
+				// *every* packet handed to it - not just packets that matched our u32
+				// filter - because at that point the whole prio+filter+netem tree
+				// (which is what implemented the IP scoping) has already been
+				// unlinked. That is the actual cause of "all IPs lose traffic during
+				// teardown": deleting 'parent 1:1/1:2/1:3' qdiscs above goes through
+				// prio's classful cops->graft() instead, which atomically substitutes
+				// a default pfifo qdisc under sch_tree_lock and never touches
+				// dev_queue->qdisc, so it never has this effect.
+				//
+				// Leaving the now-empty, non-lossy, filter-less prio qdisc attached as
+				// root is a deliberate, low-risk trade-off: the interface keeps a
+				// harmless 3-band FIFO qdisc instead of its original default, but
+				// every packet flows through it unaffected. startNetemContainerIPFilter
+				// uses 'qdisc replace' (not 'add') for the root so a later netem run on
+				// the same container remains idempotent against this leftover state.
 			}
 		} else {
 			netemCommands = [][]string{
@@ -140,9 +168,15 @@ func (client dockerClient) startNetemContainerIPFilter(ctx context.Context, req 
 
 		commands := [][]string{
 			// Create a priority-based queue. This *instantly* creates classes 1:1, 1:2, 1:3
-			// 'tc qdisc add dev <netInterface> root handle 1: prio'
+			// 'tc qdisc replace dev <netInterface> root handle 1: prio'
+			// 'replace' (rather than 'add') so this is idempotent if a prior netem run's
+			// teardown intentionally left this same root qdisc in place (see the comment
+			// on the "do NOT delete the root prio qdisc" line in stopNetemContainer):
+			// replacing an already-identical root qdisc goes through the kernel's
+			// in-place qdisc_change() path, not a graft, so it does not incur the
+			// dev_deactivate()/noop_qdisc drop window either.
 			// See more: http://man7.org/linux/man-pages/man8/tc-netem.8.html
-			{"qdisc", "add", "dev", req.Interface, "root", "handle", "1:", "prio"},
+			{"qdisc", "replace", "dev", req.Interface, "root", "handle", "1:", "prio"},
 			// Create Stochastic Fairness Queueing (sfq) queueing discipline for 1:1 class.
 			// 'tc qdisc add dev <netInterface> parent 1:1 handle 10: sfq'
 			// See more: https://linux.die.net/man/8/tc-sfq

--- a/pkg/runtime/docker/netem_test.go
+++ b/pkg/runtime/docker/netem_test.go
@@ -110,7 +110,7 @@ func TestNetemContainerIPFilter_Success(t *testing.T) {
 	engineClient.EXPECT().ContainerExecAttach(ctx, "checkID", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "checkID").Return(ctypes.ExecInspect{}, nil)
 
-	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
+	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
 	engineClient.EXPECT().ContainerExecCreate(ctx, "abc123", config1).Return(ctypes.ExecCreateResponse{ID: "cmd1"}, nil)
 	engineClient.EXPECT().ContainerExecAttach(ctx, "cmd1", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "cmd1").Return(ctypes.ExecInspect{}, nil)
@@ -162,7 +162,7 @@ func TestNetemContainerSportFilter_Success(t *testing.T) {
 	engineClient.EXPECT().ContainerExecAttach(ctx, "checkID", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "checkID").Return(ctypes.ExecInspect{}, nil)
 
-	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
+	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
 	engineClient.EXPECT().ContainerExecCreate(ctx, "abc123", config1).Return(ctypes.ExecCreateResponse{ID: "cmd1"}, nil)
 	engineClient.EXPECT().ContainerExecAttach(ctx, "cmd1", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "cmd1").Return(ctypes.ExecInspect{}, nil)
@@ -214,7 +214,7 @@ func TestNetemContainerDportFilter_Success(t *testing.T) {
 	engineClient.EXPECT().ContainerExecAttach(ctx, "checkID", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "checkID").Return(ctypes.ExecInspect{}, nil)
 
-	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "add", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
+	config1 := ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: []string{"tc", "qdisc", "replace", "dev", "eth0", "root", "handle", "1:", "prio"}, Privileged: true}
 	engineClient.EXPECT().ContainerExecCreate(ctx, "abc123", config1).Return(ctypes.ExecCreateResponse{ID: "cmd1"}, nil)
 	engineClient.EXPECT().ContainerExecAttach(ctx, "cmd1", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 	engineClient.EXPECT().ContainerExecInspect(ctx, "cmd1").Return(ctypes.ExecInspect{}, nil)
@@ -415,7 +415,7 @@ func TestNetemContainer(t *testing.T) {
 				api.EXPECT().ContainerExecCreate(ctx, c.ID(), ctypes.ExecOptions{
 					AttachStdout: true,
 					AttachStderr: true,
-					Cmd:          []string{"tc", "qdisc", "add", "dev", netInterface, "root", "handle", "1:", "prio"},
+					Cmd:          []string{"tc", "qdisc", "replace", "dev", netInterface, "root", "handle", "1:", "prio"},
 					Privileged:   true,
 				}).Return(ctypes.ExecCreateResponse{ID: "cmd1"}, nil)
 				api.EXPECT().ContainerExecAttach(ctx, "cmd1", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
@@ -579,7 +579,13 @@ func TestStopNetemIPTables(t *testing.T) {
 				api.EXPECT().ContainerExecAttach(ctx, "whichID", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 				api.EXPECT().ContainerExecInspect(ctx, "whichID").Return(ctypes.ExecInspect{}, nil)
 
-				// Need to remove child qdiscs first
+				// Remove the classifier first, then the per-band child qdiscs. The root
+				// prio qdisc is intentionally left in place (see stopNetemContainer).
+				tcCmd0 := []string{"filter", "del", "dev", netInterface, "parent", "1:0"}
+				api.EXPECT().ContainerExecCreate(ctx, c.ID(), ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: append([]string{"tc"}, tcCmd0...), Privileged: true}).Return(ctypes.ExecCreateResponse{ID: "execID0"}, nil)
+				api.EXPECT().ContainerExecAttach(ctx, "execID0", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
+				api.EXPECT().ContainerExecInspect(ctx, "execID0").Return(ctypes.ExecInspect{}, nil)
+
 				tcCmd1 := []string{"qdisc", "del", "dev", netInterface, "parent", "1:1", "handle", "10:"}
 				api.EXPECT().ContainerExecCreate(ctx, c.ID(), ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: append([]string{"tc"}, tcCmd1...), Privileged: true}).Return(ctypes.ExecCreateResponse{ID: "execID1"}, nil)
 				api.EXPECT().ContainerExecAttach(ctx, "execID1", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
@@ -594,12 +600,6 @@ func TestStopNetemIPTables(t *testing.T) {
 				api.EXPECT().ContainerExecCreate(ctx, c.ID(), ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: append([]string{"tc"}, tcCmd3...), Privileged: true}).Return(ctypes.ExecCreateResponse{ID: "execID3"}, nil)
 				api.EXPECT().ContainerExecAttach(ctx, "execID3", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
 				api.EXPECT().ContainerExecInspect(ctx, "execID3").Return(ctypes.ExecInspect{}, nil)
-
-				// Finally remove the root qdisc
-				tcCmd4 := []string{"qdisc", "del", "dev", netInterface, "root", "handle", "1:", "prio"}
-				api.EXPECT().ContainerExecCreate(ctx, c.ID(), ctypes.ExecOptions{AttachStdout: true, AttachStderr: true, Cmd: append([]string{"tc"}, tcCmd4...), Privileged: true}).Return(ctypes.ExecCreateResponse{ID: "execID4"}, nil)
-				api.EXPECT().ContainerExecAttach(ctx, "execID4", ctypes.ExecAttachOptions{}).Return(fakeExecAttach(), nil)
-				api.EXPECT().ContainerExecInspect(ctx, "execID4").Return(ctypes.ExecInspect{}, nil)
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Root cause

Fixes #166.

When `netem loss` is scoped to specific target IP(s)/port(s), `startNetemContainerIPFilter` (`pkg/runtime/docker/netem.go`, mirrored by `buildNetemCommands` in `pkg/runtime/containerd/commands.go`) builds this qdisc tree:

```
1:        root qdisc (prio, 3 bands -> classes 1:1, 1:2, 1:3)
1:1  1:2  1:3
 |    |    |
10:  20:  30:
sfq  sfq  netem loss X%
```
A u32 filter (`parent 1:0`) redirects only the target IP/port's traffic into `flowid 1:3`; everything else is classified by `prio`'s default priomap into bands 1:1/1:2 (plain `sfq`, no loss).

Teardown (`stopNetemContainer` / `buildStopNetemCommands`) used to run, in order:
```
tc qdisc del dev IFACE parent 1:1 handle 10:
tc qdisc del dev IFACE parent 1:2 handle 20:
tc qdisc del dev IFACE parent 1:3 handle 30:
tc qdisc del dev IFACE root handle 1: prio   <-- the problem
```

The last command deletes the **root** qdisc. In the kernel, any root-qdisc graft goes through `qdisc_graft()`'s `parent == NULL` branch (`net/sched/sch_api.c`):

```c
if (dev->flags & IFF_UP)
    dev_deactivate(dev, false);
... /* graft new/default qdisc onto every tx queue */
if (dev->flags & IFF_UP)
    dev_activate(dev);
```

`dev_deactivate()` → `dev_deactivate_many()` → `dev_deactivate_queue()` (`net/sched/sch_generic.c`) installs `noop_qdisc` on **every tx queue of the device** for the duration of the swap:

```c
rcu_assign_pointer(dev_queue->qdisc, &noop_qdisc);
```

and `noop_qdisc`'s enqueue drops everything unconditionally:

```c
static int noop_enqueue(struct sk_buff *skb, struct Qdisc *qdisc, struct sk_buff **to_free)
{
    dev_core_stats_tx_dropped_inc(skb->dev);
    __qdisc_drop(skb, to_free);
    return NET_XMIT_CN;
}
```

At the moment the root qdisc is deleted, the whole `prio` + filter + `netem` tree that implemented the IP scoping has already been unlinked, so during this window *every* packet on the interface is dropped — not just packets to the originally-targeted IP(s). That's exactly the reported symptom.

By contrast, the three preceding `qdisc del ... parent 1:1/1:2/1:3` commands are **non-root class grafts**, which go through `prio`'s `cops->graft()` (`prio_graft()` in `net/sched/sch_prio.c`). That function does *not* call `dev_deactivate`/`dev_activate` — it's a lock-protected pointer swap under `sch_tree_lock` that substitutes a default `pfifo` qdisc (not `noop_qdisc`) when deleting:

```c
static int prio_graft(struct Qdisc *sch, unsigned long arg, struct Qdisc *new, ...)
{
    if (!new) {
        new = qdisc_create_dflt(sch->dev_queue, &pfifo_qdisc_ops, ...);
        ...
    }
    *old = qdisc_replace(sch, new, &q->queues[band]);
    ...
}
```

So those three commands are safe; only the final root-qdisc deletion causes the all-traffic drop. This also explains why the bug is specific to the IP/port-filtered path: the simple (unfiltered) `netem` path also deletes its root qdisc (`tc qdisc del dev IFACE root netem`) and goes through the same `dev_deactivate`/`noop_qdisc` window, but that's invisible there because *all* traffic was already meant to be disrupted.

## Fix

- Stop deleting the root `prio` qdisc during IP/port-scoped teardown. Instead:
  1. Delete the u32 filter(s) first (`tc filter del dev IFACE parent 1:0` — a classifier-list operation that never touches `dev_queue->qdisc`, so target traffic falls back to the loss-free default bands 1:1/1:2 immediately).
  2. Delete the three per-band child qdiscs as before (safe, atomic default-pfifo substitution, confirmed via `prio_graft` above).
  3. Leave the now-empty, filter-less, non-lossy root `prio` qdisc attached to the interface.
- Since the root qdisc is intentionally left behind, `startNetemContainerIPFilter` / `buildNetemCommands` now use `tc qdisc replace ... root handle 1: prio` instead of `tc qdisc add`, so a later netem run on the same container doesn't fail with "File exists". Per `__tc_modify_qdisc()` in `net/sched/sch_api.c`, when the existing root qdisc already has the same handle and kind, `replace` resolves to the kernel's in-place `qdisc_change()` path (`prio_tune()`), not a graft — so this doesn't reintroduce a `dev_deactivate`/`noop_qdisc` window either, and `prio_tune()` leaves already-existing per-band children untouched when the band count is unchanged (which it always is here), so nothing needs to be re-created that isn't already handled by the subsequent per-band `qdisc add` / `filter add` commands.

Both the Docker (`pkg/runtime/docker/netem.go`) and containerd (`pkg/runtime/containerd/commands.go`) implementations had the identical bug (independently duplicated tc command sequences) and are both fixed the same way. Podman delegates to the Docker client, so it's covered too.

## Validation

- This sandbox has no Linux/tc access, so this is grounded in exact, current kernel source (`torvalds/linux` `net/sched/sch_api.c`, `net/sched/sch_generic.c`, `net/sched/sch_prio.c`, verified by direct fetch, function names/lines quoted above), not just a plausible-sounding narrative.
- Updated the existing tc-command-sequence unit tests (which assert on exact `tc` argv, no live networking needed) in `pkg/runtime/docker/netem_test.go` and `pkg/runtime/containerd/client_test.go` to lock in the new sequence as a regression test.
- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` (pinned v2.12.0) all pass clean.