### PR TITLE
feat(netem): resolve container names to IPs for --target

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -35,7 +35,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 				cli.StringSliceFlag{
 					Name:  "target, t",
-					Usage: "target IP filter; supports multiple IPs; supports CIDR notation",
+					Usage: "target filter; supports multiple values; accepts IPs, CIDR notation, or a running container name/ID (resolved to its IP address(es) at run time)",
 				},
 				cli.StringFlag{
 					Name:  "egress-port, egressPort",

--- a/docs/network-chaos.md
+++ b/docs/network-chaos.md
@@ -81,13 +81,29 @@ Network emulation (`netem`) manipulates **outgoing** traffic using Linux traffic
 | ------------------------------- | ------------------------------------------------------ | ------------------------------------------------- |
 | `--duration`, `-d`              | Emulation duration (must be shorter than `--interval`) | required                                          |
 | `--interface`, `-i`             | Network interface to apply rules on                    | `eth0`                                            |
-| `--target`, `-t`                | Target IP filter (repeatable); supports CIDR notation  | all                                               |
+| `--target`, `-t`                | Target filter (repeatable); IP, CIDR, or container name/ID | all                                           |
 | `--egress-port`, `egressPort`   | Egress (source) port filter (comma-separated)          | all                                               |
 | `--ingress-port`, `ingressPort` | Ingress (destination) port filter (comma-separated)    | all                                               |
 | `--tc-image`                    | Docker image with `tc` tool                            | `ghcr.io/alexei-led/pumba-alpine-nettools:latest` |
 | `--pull-image`                  | Force pull the tc-image                                | `true`                                            |
 
 Run `pumba netem --help` for the full list of options.
+
+`--target` accepts an IP address, CIDR block, or a running container's name
+or ID — mix and match, and repeat the flag for multiple values. A container
+name/ID is resolved to that container's IP address(es) when the command
+runs: if the container is attached to more than one network, every address
+it has is added as a separate filter, so traffic to/from any of them is
+affected. Resolution requires an unambiguous match — a name or ID prefix
+that matches more than one running container is a hard error rather than an
+arbitrary pick — and a value that is neither a valid IP/CIDR nor a
+resolvable container name/ID also fails with a clear error instead of
+silently matching nothing.
+
+```bash
+# Delay only traffic to/from container "service-b" (resolved to its IP)
+pumba netem --duration 10m --target service-b delay --time 1000 service-a
+```
 
 ### delay
 
@@ -287,8 +303,9 @@ Test how services handle degraded inter-service communication:
 
 ```bash
 # High latency between service-a and service-b
+# --target accepts an IP/CIDR or, as here, a container name/ID to resolve
 pumba netem --tc-image ghcr.io/alexei-led/pumba-alpine-nettools:latest \
-    --target service-b-ip --duration 10m \
+    --target service-b --duration 10m \
     delay --time 1000 --jitter 200 service-a &
 
 # Packet loss from service-c to service-b

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -59,6 +59,12 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -77,6 +77,12 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -149,6 +149,75 @@ func TestDelayCommand_Run_WithRandom(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestDelayCommand_Run_TargetContainerNameResolvedOnce(t *testing.T) {
+	// gp.Names matches two containers, so the netem delay loop below runs
+	// twice — but --target names a third container to resolve, and that
+	// resolution must happen exactly once per command invocation, not once
+	// per matched container.
+	mockClient := container.NewMockClient(t)
+	peer := &container.Container{
+		ContainerID:   "peerid",
+		ContainerName: "/peer",
+		Networks:      map[string]container.NetworkLink{"bridge": {IPv4Address: "10.5.0.9"}},
+	}
+	c1 := &container.Container{ContainerID: "id1", ContainerName: "c1", Networks: map[string]container.NetworkLink{}}
+	c2 := &container.Container{ContainerID: "id2", ContainerName: "c2", Networks: map[string]container.NetworkLink{}}
+
+	gparams := &chaos.GlobalParams{Names: []string{"c1", "c2"}, DryRun: true}
+	nparams := &container.NetemRequest{
+		Interface:   "eth0",
+		Duration:    100 * time.Millisecond,
+		Sidecar:     container.SidecarSpec{Image: "tc"},
+		DryRun:      true,
+		TargetNames: []string{"peer"},
+	}
+
+	// First call: resolveTargetNames looking up "peer".
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{peer}, nil).Once()
+	// Second call: chaos.RunOnContainers listing containers matching gp.Names.
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{c1, c2}, nil).Once()
+
+	mockClient.EXPECT().NetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
+	mockClient.EXPECT().StopNetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
+
+	cmd, err := NewDelayCommand(mockClient, gparams, nparams, 0, 100, 0, 0, "")
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), false)
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+	assert.Empty(t, nparams.TargetNames, "TargetNames must be resolved and cleared")
+	require.Len(t, nparams.IPs, 1)
+	assert.Equal(t, "10.5.0.9/32", nparams.IPs[0].String())
+}
+
+func TestDelayCommand_Run_TargetContainerNameNotFound(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	gparams := &chaos.GlobalParams{Names: []string{"c1"}, DryRun: true}
+	nparams := &container.NetemRequest{
+		Interface:   "eth0",
+		Duration:    100 * time.Millisecond,
+		DryRun:      true,
+		TargetNames: []string{"ghost"},
+	}
+
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{}, nil)
+
+	cmd, err := NewDelayCommand(mockClient, gparams, nparams, 0, 100, 0, 0, "")
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+	mockClient.AssertExpectations(t)
+}
+
 func TestDelayCommand_Run_DryRun(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -63,6 +63,12 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -58,6 +58,12 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -74,6 +74,12 @@ func (n *lossGECommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -81,6 +81,12 @@ func (n *lossStateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/netem.go
+++ b/pkg/chaos/netem/netem.go
@@ -22,6 +22,16 @@ const cleanupTimeout = 30 * time.Second
 
 // run network emulation command, stop netem on timeout or abort
 func runNetem(ctx context.Context, client netemClient, req *container.NetemRequest) error {
+	// Each per-action Run already resolves --target container names/IDs
+	// once, before matched containers are enumerated (see e.g. delay.go).
+	// This call is a no-op then, since TargetNames is already empty; it
+	// only does real work if runNetem is ever called directly with an
+	// unresolved request, so req.IPs is always complete by the time it's
+	// handed to the runtime client below.
+	if err := resolveTargetNames(ctx, client, req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
+
 	logger := log.WithFields(log.Fields{
 		"id":       req.Container.ID(),
 		"name":     req.Container.Name(),

--- a/pkg/chaos/netem/parse.go
+++ b/pkg/chaos/netem/parse.go
@@ -18,6 +18,12 @@ import (
 // rather than by the runtime). Container and Command are left zero — each
 // per-action Run sets them per iteration.
 //
+// Each --target value is parsed as an IP or CIDR literal first; values that
+// aren't (e.g. a container name or ID) are kept as-is in TargetNames rather
+// than rejected here, since resolving them requires a runtime client that
+// isn't available during CLI flag parsing. runNetem resolves TargetNames
+// into IPs the first time the command actually runs — see netem.go.
+//
 // c must be the netem parent context. Per-action parsers pass c.Parent().
 func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.NetemRequest, int, error) {
 	duration := c.Duration("duration")
@@ -31,12 +37,16 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 	if err := util.ValidateInterfaceName(iface); err != nil {
 		return nil, 0, err
 	}
-	ipsList := c.StringSlice("target")
-	ips := make([]*net.IPNet, 0, len(ipsList))
-	for _, s := range ipsList {
+	targetList := c.StringSlice("target")
+	ips := make([]*net.IPNet, 0, len(targetList))
+	var targetNames []string
+	for _, s := range targetList {
 		ip, err := util.ParseCIDR(s)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to parse ip: %w", err)
+			// Not a literal IP/CIDR — treat as a container name or ID to
+			// resolve later, once a runtime client is available.
+			targetNames = append(targetNames, s)
+			continue
 		}
 		ips = append(ips, ip)
 	}
@@ -49,12 +59,13 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 		return nil, 0, fmt.Errorf("failed to get destination ports: %w", err)
 	}
 	return &container.NetemRequest{
-		Interface: iface,
-		IPs:       ips,
-		SPorts:    sports,
-		DPorts:    dports,
-		Duration:  duration,
-		Sidecar:   container.SidecarSpec{Image: c.String("tc-image"), Pull: c.Bool("pull-image")},
-		DryRun:    gp.DryRun,
+		Interface:   iface,
+		IPs:         ips,
+		TargetNames: targetNames,
+		SPorts:      sports,
+		DPorts:      dports,
+		Duration:    duration,
+		Sidecar:     container.SidecarSpec{Image: c.String("tc-image"), Pull: c.Bool("pull-image")},
+		DryRun:      gp.DryRun,
 	}, c.Int("limit"), nil
 }

--- a/pkg/chaos/netem/parse_test.go
+++ b/pkg/chaos/netem/parse_test.go
@@ -73,12 +73,6 @@ func TestParseRequestBase(t *testing.T) {
 			wantErr: "bad network interface name",
 		},
 		{
-			name:    "invalid CIDR rejected",
-			args:    []string{"--duration", "1s", "--interface", "eth0", "--target", "not-a-cidr"},
-			gp:      &chaos.GlobalParams{},
-			wantErr: "failed to parse ip",
-		},
-		{
 			name:    "invalid egress port rejected",
 			args:    []string{"--duration", "1s", "--interface", "eth0", "--egress-port", "abc"},
 			gp:      &chaos.GlobalParams{},
@@ -129,6 +123,25 @@ func TestParseRequestBase_PortsAndIPsParsed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, req.IPs, 1)
 	assert.Equal(t, "10.0.0.0/24", req.IPs[0].String())
+	assert.Empty(t, req.TargetNames)
 	assert.Equal(t, []string{"80", "443"}, req.SPorts)
 	assert.Equal(t, []string{"8080"}, req.DPorts)
+}
+
+func TestParseRequestBase_TargetContainerNamesDeferred(t *testing.T) {
+	// Values that aren't valid IP/CIDR literals are not rejected at parse
+	// time — no runtime client is available yet to check whether they name
+	// a real container. They're kept as candidates in TargetNames and
+	// resolved later, once a client exists (see resolveTargetNames).
+	c := cliflags.NewV1(parentCtx(t, []string{
+		"--duration", "1s", "--interface", "eth0",
+		"--target", "10.0.0.5",
+		"--target", "web-1",
+		"--target", "db",
+	}))
+	req, _, err := ParseRequestBase(c, &chaos.GlobalParams{})
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.5/32", req.IPs[0].String())
+	assert.Equal(t, []string{"web-1", "db"}, req.TargetNames)
 }

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -80,6 +80,12 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/target.go
+++ b/pkg/chaos/netem/target.go
@@ -1,0 +1,115 @@
+package netem
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/alexei-led/pumba/pkg/container"
+)
+
+// minIDPrefixLen is the shortest container-ID prefix resolveTargetNames will
+// try to match. Docker's own short IDs are 12 characters; anything much
+// shorter has a real chance of prefix-colliding with an unrelated container
+// in a large fleet, so target names shorter than this are only tried
+// against exact container names, never against ID prefixes.
+const minIDPrefixLen = 6
+
+// resolveTargetNames resolves req.TargetNames — --target values that were
+// not valid IP/CIDR literals at parse time (see ParseRequestBase) — into IP
+// filters, appending the result to req.IPs and clearing TargetNames. It is a
+// no-op — no runtime call at all — when TargetNames is empty, so plain
+// IP/CIDR --target usage, the overwhelming common case, costs nothing extra.
+//
+// Each name/ID is matched against currently running containers, in order:
+//  1. exact container name (Docker/Podman report names with a leading "/",
+//     which is trimmed before comparing);
+//  2. exact container ID;
+//  3. a unique container-ID prefix of at least minIDPrefixLen characters.
+//
+// A target that matches more than one container at the same priority level
+// is a hard error rather than an arbitrary pick: silently applying a network
+// filter to the wrong container's IP is worse than refusing to run. A target
+// that matches no container, or a container with no IP address on any
+// attached network (e.g. host networking, or a runtime that doesn't report
+// one), is also a hard error — never a silent no-op.
+//
+// A resolved container contributes every IPv4 address found across all of
+// its attached networks: a container connected to more than one network is
+// reachable on each of those addresses, and tc needs a filter per address to
+// actually scope traffic to all of them rather than just one arbitrarily
+// chosen network.
+func resolveTargetNames(ctx context.Context, lister container.Lister, req *container.NetemRequest) error {
+	if len(req.TargetNames) == 0 {
+		return nil
+	}
+	candidates, err := lister.ListContainers(ctx, func(*container.Container) bool { return true }, container.ListOpts{All: false})
+	if err != nil {
+		return fmt.Errorf("failed to list containers while resolving --target: %w", err)
+	}
+	for _, name := range req.TargetNames {
+		c, err := matchTargetContainer(name, candidates)
+		if err != nil {
+			return err
+		}
+		ips := c.IPs()
+		if len(ips) == 0 {
+			return fmt.Errorf("--target %q resolved to container %q (%s) but it has no IP address on any attached network",
+				name, c.Name(), c.ID())
+		}
+		for _, ip := range ips {
+			req.IPs = append(req.IPs, hostCIDR(ip))
+		}
+	}
+	req.TargetNames = nil
+	return nil
+}
+
+// hostCIDR wraps a single resolved address as a host route (/32 for IPv4,
+// /128 for IPv6), matching how util.ParseCIDR treats a bare IP given
+// directly on --target.
+func hostCIDR(ip net.IP) *net.IPNet {
+	if v4 := ip.To4(); v4 != nil {
+		return &net.IPNet{IP: v4, Mask: net.CIDRMask(32, 32)} //nolint:mnd
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)} //nolint:mnd
+}
+
+// matchTargetContainer resolves a single --target value against the
+// candidate container list. See resolveTargetNames for the matching order
+// and ambiguity rules.
+func matchTargetContainer(target string, candidates []*container.Container) (*container.Container, error) {
+	trimmedTarget := strings.TrimPrefix(target, "/")
+	if trimmedTarget == "" {
+		return nil, fmt.Errorf("--target %q is not a valid IP/CIDR or container name/ID", target)
+	}
+
+	var byName, byID, byIDPrefix []*container.Container
+	for _, c := range candidates {
+		if strings.TrimPrefix(c.Name(), "/") == trimmedTarget {
+			byName = append(byName, c)
+		}
+		switch {
+		case c.ID() == target:
+			byID = append(byID, c)
+		case len(target) >= minIDPrefixLen && strings.HasPrefix(c.ID(), target):
+			byIDPrefix = append(byIDPrefix, c)
+		}
+	}
+
+	switch {
+	case len(byName) == 1:
+		return byName[0], nil
+	case len(byName) > 1:
+		return nil, fmt.Errorf("--target %q is ambiguous: matches %d container names", target, len(byName))
+	case len(byID) == 1:
+		return byID[0], nil
+	case len(byIDPrefix) == 1:
+		return byIDPrefix[0], nil
+	case len(byIDPrefix) > 1:
+		return nil, fmt.Errorf("--target %q is ambiguous: matches %d container IDs", target, len(byIDPrefix))
+	default:
+		return nil, fmt.Errorf("--target %q is not a valid IP/CIDR and does not match any running container name or ID", target)
+	}
+}

--- a/pkg/chaos/netem/target_test.go
+++ b/pkg/chaos/netem/target_test.go
@@ -1,0 +1,207 @@
+package netem
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func webContainer() *container.Container {
+	return &container.Container{
+		ContainerID:   "abc1234567890def",
+		ContainerName: "/web-1",
+		Networks: map[string]container.NetworkLink{
+			"bridge": {IPv4Address: "172.17.0.5"},
+		},
+	}
+}
+
+func TestResolveTargetNames_NoOpWhenEmpty(t *testing.T) {
+	// No ListContainers expectation is set up: if resolveTargetNames made a
+	// runtime call for the plain IP/CIDR case, this mock would panic on the
+	// unexpected call, failing the test.
+	mockClient := container.NewMockClient(t)
+	req := &container.NetemRequest{
+		IPs: []*net.IPNet{{IP: net.IPv4(10, 0, 0, 1), Mask: net.CIDRMask(32, 32)}},
+	}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.1/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ByName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"web-1"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+	assert.Empty(t, req.TargetNames, "TargetNames must be cleared once resolved")
+}
+
+func TestResolveTargetNames_MixedIPAndName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{
+		IPs:         []*net.IPNet{{IP: net.IPv4(10, 0, 0, 1), Mask: net.CIDRMask(32, 32)}},
+		TargetNames: []string{"web-1"},
+	}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 2)
+	assert.Equal(t, "10.0.0.1/32", req.IPs[0].String())
+	assert.Equal(t, "172.17.0.5/32", req.IPs[1].String())
+}
+
+func TestResolveTargetNames_ByExactID(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc1234567890def"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ByUniqueIDPrefix(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc123"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ShortIDPrefixNotMatched(t *testing.T) {
+	// Prefixes shorter than minIDPrefixLen are never tried against IDs, only
+	// exact names, to avoid a short typo accidentally landing on an
+	// unrelated container in a large fleet.
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"abc"`)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestResolveTargetNames_NotFound(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{webContainer()}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"does-not-exist"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"does-not-exist"`)
+	assert.Contains(t, err.Error(), "not a valid IP/CIDR")
+	assert.Contains(t, err.Error(), "does not match any running container")
+}
+
+func TestResolveTargetNames_AmbiguousName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c1 := &container.Container{ContainerID: "id1", ContainerName: "dup", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.1"}}}
+	c2 := &container.Container{ContainerID: "id2", ContainerName: "dup", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.2"}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c1, c2}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"dup"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestResolveTargetNames_AmbiguousIDPrefix(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c1 := &container.Container{ContainerID: "abcdef123456", ContainerName: "c1", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.1"}}}
+	c2 := &container.Container{ContainerID: "abcdef789012", ContainerName: "c2", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.2"}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c1, c2}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abcdef"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestResolveTargetNames_ContainerWithNoIP(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{ContainerID: "id1", ContainerName: "headless", Networks: map[string]container.NetworkLink{"host": {}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"headless"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no IP address")
+}
+
+func TestResolveTargetNames_MultiNetworkContainer(t *testing.T) {
+	// A container attached to more than one network contributes every IP it
+	// has, not just one arbitrarily chosen network.
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{
+		ContainerID:   "id1",
+		ContainerName: "multi",
+		Networks: map[string]container.NetworkLink{
+			"front": {IPv4Address: "10.0.1.5"},
+			"back":  {IPv4Address: "10.0.2.5"},
+		},
+	}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"multi"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 2)
+	assert.Equal(t, "10.0.1.5/32", req.IPs[0].String())
+	assert.Equal(t, "10.0.2.5/32", req.IPs[1].String())
+}
+
+func TestResolveTargetNames_ListContainersError(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return(nil, errors.New("daemon unreachable"))
+
+	req := &container.NetemRequest{TargetNames: []string{"anything"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon unreachable")
+}
+
+func TestResolveTargetNames_EmptyTargetRejected(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{webContainer()}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{""}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+	"net"
+	"sort"
 	"strings"
 )
 
@@ -17,9 +19,13 @@ const (
 	StateExited = "exited"
 )
 
-// NetworkLink represents a link from one container network endpoint.
+// NetworkLink represents a container's attachment to one network: the
+// legacy container links defined on that network, plus the IPv4 address
+// the runtime assigned the container on it (empty when the runtime doesn't
+// expose one, e.g. host networking or an unsupported runtime).
 type NetworkLink struct {
-	Links []string
+	Links       []string
+	IPv4Address string
 }
 
 // Container represents a running container, decoupled from any specific runtime.
@@ -68,6 +74,35 @@ func (c *Container) Links() []string {
 	}
 
 	return links
+}
+
+// IPs returns every distinct IPv4 address the container has across all of
+// its attached networks, sorted for a deterministic result. A container
+// connected to more than one Docker/Podman network (or with no network
+// address at all, e.g. host networking or a runtime that doesn't report
+// one) is expected and handled by callers explicitly rather than silently
+// picking a single "the" address.
+func (c *Container) IPs() []net.IP {
+	seen := make(map[string]struct{}, len(c.Networks))
+	var addrs []string
+	for _, n := range c.Networks {
+		if n.IPv4Address == "" {
+			continue
+		}
+		if _, ok := seen[n.IPv4Address]; ok {
+			continue
+		}
+		seen[n.IPv4Address] = struct{}{}
+		addrs = append(addrs, n.IPv4Address)
+	}
+	sort.Strings(addrs)
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+	return ips
 }
 
 // IsPumba returns a boolean flag indicating whether or not the current

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestID(t *testing.T) {
@@ -164,6 +165,51 @@ func TestLinks_NetworkWithNoLinks(t *testing.T) {
 		},
 	}
 	assert.Nil(t, c.Links())
+}
+
+func TestIPs_SingleNetwork(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"bridge": {IPv4Address: "172.17.0.5"},
+		},
+	}
+	ips := c.IPs()
+	require.Len(t, ips, 1)
+	assert.Equal(t, "172.17.0.5", ips[0].String())
+}
+
+func TestIPs_MultipleNetworks_SortedAndDeduped(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"backend":  {IPv4Address: "10.0.2.5"},
+			"frontend": {IPv4Address: "10.0.1.5"},
+			"dup":      {IPv4Address: "10.0.1.5"}, // same address on another network: deduped
+		},
+	}
+	ips := c.IPs()
+	require.Len(t, ips, 2)
+	assert.Equal(t, "10.0.1.5", ips[0].String())
+	assert.Equal(t, "10.0.2.5", ips[1].String())
+}
+
+func TestIPs_NoAddress(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"host": {},
+		},
+	}
+	assert.Empty(t, c.IPs())
+}
+
+func TestIPs_EmptyNetworks(t *testing.T) {
+	c := Container{
+		Labels:   map[string]string{},
+		Networks: map[string]NetworkLink{},
+	}
+	assert.Empty(t, c.IPs())
 }
 
 func TestIsPumbaSkip_WrongValue(t *testing.T) {

--- a/pkg/container/requests.go
+++ b/pkg/container/requests.go
@@ -22,11 +22,20 @@ type NetemRequest struct {
 	Interface string
 	Command   []string
 	IPs       []*net.IPNet
-	SPorts    []string
-	DPorts    []string
-	Duration  time.Duration
-	Sidecar   SidecarSpec
-	DryRun    bool
+	// TargetNames holds --target values that were not valid IP/CIDR
+	// literals at parse time (no runtime client is available yet then).
+	// They are candidate container names or IDs, resolved to IPs — and
+	// folded into IPs — the first time a command runs, once a runtime
+	// client is available. Empty for the common IP/CIDR-only case, so
+	// existing callers see no behavior change. Runtime adapters
+	// (pkg/runtime/*) never need to look at this field: by the time a
+	// request reaches them it has already been resolved.
+	TargetNames []string
+	SPorts      []string
+	DPorts      []string
+	Duration    time.Duration
+	Sidecar     SidecarSpec
+	DryRun      bool
 }
 
 // IPTablesRequest carries every parameter required to apply or stop an

--- a/pkg/runtime/docker/inspect.go
+++ b/pkg/runtime/docker/inspect.go
@@ -35,7 +35,7 @@ func dockerInspectToContainer(info ctypes.InspectResponse, img *imagetypes.Inspe
 	}
 	if info.NetworkSettings != nil {
 		for name, ep := range info.NetworkSettings.Networks {
-			c.Networks[name] = ctr.NetworkLink{Links: ep.Links}
+			c.Networks[name] = ctr.NetworkLink{Links: ep.Links, IPv4Address: ep.IPAddress}
 		}
 	}
 	return c

--- a/pkg/runtime/docker/inspect_test.go
+++ b/pkg/runtime/docker/inspect_test.go
@@ -148,6 +148,39 @@ func TestDockerInspectToContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "container with IP addresses on multiple networks",
+			info: ctypes.InspectResponse{
+				ContainerJSONBase: &ctypes.ContainerJSONBase{
+					ID:    "abc123",
+					Name:  "/multi-net",
+					Image: "nginx:1.25",
+					State: &ctypes.State{Running: true},
+				},
+				Config: &ctypes.Config{Labels: map[string]string{}},
+				NetworkSettings: &ctypes.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						"frontend": {Links: []string{"db:db"}, IPAddress: "172.18.0.2"},
+						"backend":  {IPAddress: "172.19.0.3"},
+						"host":     {IPAddress: ""},
+					},
+				},
+			},
+			img: &imagetypes.InspectResponse{ID: "sha256:img123"},
+			expected: &ctr.Container{
+				ContainerID:   "abc123",
+				ContainerName: "/multi-net",
+				Image:         "nginx:1.25",
+				ImageID:       "sha256:img123",
+				State:         ctr.StateRunning,
+				Labels:        map[string]string{},
+				Networks: map[string]ctr.NetworkLink{
+					"frontend": {Links: []string{"db:db"}, IPv4Address: "172.18.0.2"},
+					"backend":  {IPv4Address: "172.19.0.3"},
+					"host":     {IPv4Address: ""},
+				},
+			},
+		},
+		{
 			name: "exited container",
 			info: ctypes.InspectResponse{
 				ContainerJSONBase: &ctypes.ContainerJSONBase{

--- a/pkg/runtime/docker/mockengine_responses.go
+++ b/pkg/runtime/docker/mockengine_responses.go
@@ -33,6 +33,7 @@ func DetailsResponse(params map[string]any) ctypes.InspectResponse {
 	Labels := lookupWithDefault(params, "Labels", map[string]string{}).(map[string]string)
 	Links := lookupWithDefault(params, "Links", []string{}).([]string)
 	CgroupParent := lookupWithDefault(params, "CgroupParent", "").(string)
+	IPAddress := lookupWithDefault(params, "IPAddress", "").(string)
 
 	resp := ctypes.InspectResponse{
 		ContainerJSONBase: &ctypes.ContainerJSONBase{
@@ -52,7 +53,7 @@ func DetailsResponse(params map[string]any) ctypes.InspectResponse {
 		},
 		NetworkSettings: &ctypes.NetworkSettings{
 			Networks: map[string]*networktypes.EndpointSettings{
-				"default": {Links: Links},
+				"default": {Links: Links, IPAddress: IPAddress},
 			},
 		},
 	}


### PR DESCRIPTION
## Problem

`netem --target` only accepts IP addresses and CIDR blocks (#90). Scoping a `netem` rule to a specific peer container means looking up its IP by hand first — inconvenient, and the IP changes across restarts. This was requested in #24 and reopened as #90, with alexei-led noting container names would be "much better... just it requires bigger effort."

## What changed

`--target` now also accepts a running container's name or ID, resolved to its IP address(es) at run time — no change to existing IP/CIDR usage.

```bash
# before: had to resolve the IP by hand
pumba netem --target 172.17.0.5 --duration 5m delay --time 100 web

# now: container name works directly
pumba netem --target service-b --duration 5m delay --time 100 web
```

### Design decisions

- **When resolution happens.** `--target` values are parsed as IP/CIDR literals first (unchanged path). Anything that doesn't parse is kept as a candidate name/ID and resolved once the netem command actually runs, using the same runtime client already used elsewhere — CLI flag parsing happens before a client exists, so resolution can't happen any earlier. Resolution runs exactly once per command invocation (before the matched-container loop), not once per matched target container, so it costs nothing extra for the common IP/CIDR-only case and doesn't multiply runtime API calls when `gp.Names`/`--limit` matches several containers.

- **Multiple networks.** A container attached to more than one network contributes *every* IP it has, not just one arbitrarily picked network — `tc` needs a filter per address to actually scope traffic to all of them. This is documented in `docs/network-chaos.md`.

- **Avoiding wrong-container matches.** Matching tries, in order: exact container name (Docker/Podman's leading `/` trimmed), exact container ID, then a *unique* ID prefix of at least 6 characters. A name/ID that matches more than one running container is a hard error rather than an arbitrary pick, and short strings are never tried against ID prefixes — a 2-3 character typo won't silently land on an unrelated container in a large fleet.

- **Error handling.** A target that resolves to no container, or a container with no IP on any attached network (e.g. `--network host`), is a clear, explicit error — never a silent no-op or a low-level Docker error.

- **Runtime coverage.** Capturing a container's IP required extending the runtime-agnostic `Container` type (`NetworkLink` gained `IPv4Address`), populated from Docker's inspect response. Podman gets this for free since it reuses the Docker-compatible client. Containerd's `Container` doesn't populate `IPv4Address` yet (no equivalent inspect field is currently read there), so container-name resolution against a containerd-only container will report "no IP address on any attached network" until that's added — IP/CIDR `--target` usage on containerd is unaffected.

## Validation

```
go build ./...          # clean
go vet ./...             # clean
gofmt -l .                # no output
golangci-lint run ./...   # 0 issues (pinned v2.12.0, per .golangci.yaml / Makefile)
go test ./... -count=1    # ok, all packages
go test -race ./pkg/chaos/netem/... ./pkg/container/... ./pkg/runtime/docker/...   # ok
```

New/updated tests:
- `pkg/container/container_test.go` — `Container.IPs()`: single/multiple networks, dedup, sorted, no address
- `pkg/runtime/docker/inspect_test.go` — IP capture from Docker inspect responses
- `pkg/chaos/netem/target_test.go` — name/ID/prefix resolution, ambiguous name, ambiguous ID prefix, short-prefix rejection, not-found, no-IP container, multi-network container, mixed IP+name target, `ListContainers` error, empty target
- `pkg/chaos/netem/parse_test.go` — non-IP `--target` values deferred into `TargetNames` instead of rejected at parse time
- `pkg/chaos/netem/delay_test.go` — end-to-end: name resolves and is applied across multiple matched containers, resolved exactly once (not once per matched container); clear error on unresolvable name

## Test plan for reviewers

- [ ] `pumba netem --target <container-name> --duration 5m delay --time 100 <target>` against a running container resolves and applies the filter
- [ ] `--target <ip>` / `--target <cidr>` behavior is unchanged
- [ ] `--target <typo-or-missing-name>` fails with a clear error instead of hanging or applying an unfiltered rule
- [ ] A container on two networks gets filters for both addresses