### PR TITLE
ci: use file locks for Podman integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,6 +174,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq podman
+          sudo install -d /etc/containers/containers.conf.d
+          printf '[engine]\nlock_type = "file"\n' | sudo tee /etc/containers/containers.conf.d/99-ci-locks.conf >/dev/null
           sudo systemctl enable --now podman.socket
           sudo podman info
           sudo podman pull docker.io/library/alpine:latest &


### PR DESCRIPTION
## Problem

Every Ubuntu 24.04 arm64 integration job fails before Pumba runs:

```
Error: failed to open 2048 locks in /libpod_lock: numerical result out of range
```

Podman 4.9 defaults to shared-memory locks. The hosted arm64 runner cannot allocate that lock set.

## Change

Configure the CI-only Podman installation to use file-backed locks before its first invocation. This avoids the host semaphore limit without changing Pumba or production runtime behavior.

## Validation

- workflow YAML parses successfully
- `actionlint .github/workflows/build.yaml`
- the PR integration matrix must confirm Podman on amd64 and arm64