### PR TITLE
feat: support mixed RE2 container selectors

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -61,7 +61,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 			},
 			Usage:       "emulate the properties of wide area networks",
-			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", re2Prefix),
+			ArgsUsage:   fmt.Sprintf("containers (names and RE2 regexes prefixed with %q; may be mixed)", re2Prefix),
 			Description: "delay, loss, duplicate and re-order (run 'netem') packets, and limit the bandwidth, to emulate different network problems",
 			Subcommands: []cli.Command{
 				*netemCmd.NewDelayCLICommand(topContext, runtime),
@@ -122,7 +122,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 			},
 			Usage:       "apply IPv4 packet filter on incoming IP packets",
-			ArgsUsage:   fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q", re2Prefix),
+			ArgsUsage:   fmt.Sprintf("containers (names and RE2 regexes prefixed with %q; may be mixed)", re2Prefix),
 			Description: "emulate loss of incoming packets, all ports and address arguments will result in separate rules",
 			Subcommands: []cli.Command{
 				*ipTablesCmd.NewLossCLICommand(topContext, runtime),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 	app.EnableBashCompletion = true
 	app.Usage = "Pumba is a resilience testing tool, that helps applications tolerate random Docker container failures: process, network and performance."
-	app.ArgsUsage = fmt.Sprintf("containers (name, list of names, or RE2 regex if prefixed with %q)", re2Prefix)
+	app.ArgsUsage = fmt.Sprintf("containers (names and RE2 regexes prefixed with %q; may be mixed)", re2Prefix)
 	app.Before = before
 	app.After = func(_ *cli.Context) error {
 		if runtimeClient != nil {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -165,6 +165,9 @@ pumba kill "re2:^test"
 
 # All containers with "api" in the name
 pumba kill "re2:api"
+
+# Combine multiple regexes and exact names (all selectors use OR logic)
+pumba kill "re2:^web-" database "re2:^api-"
 ```
 
 ### By Labels

--- a/pkg/chaos/command.go
+++ b/pkg/chaos/command.go
@@ -70,30 +70,41 @@ func ParseGlobalParams(c cliflags.Flags) *GlobalParams {
 	}
 }
 
-// get names list of filter pattern from command line
+// getNamesOrPattern splits CLI arguments into exact names and RE2 patterns.
+// Multiple patterns and names may be mixed. Patterns are joined into one RE2
+// expression so GlobalParams.Pattern remains the canonical, compatible
+// selection path for all chaos commands.
 func getNamesOrPattern(c cliflags.Flags) ([]string, string) {
-	var names []string
-	pattern := ""
-	args := c.Args()
-	// no Args means ALL containers
-	if len(args) == 0 {
-		return names, pattern
+	var names, patterns []string
+	for _, arg := range c.Args() {
+		if pattern, found := strings.CutPrefix(arg, Re2Prefix); found {
+			patterns = append(patterns, pattern)
+			continue
+		}
+		names = append(names, arg)
 	}
-	// more than one argument, assume that this a list of names
-	if len(args) > 1 {
-		names = args
+
+	pattern := joinPatterns(patterns)
+	if len(names) > 0 {
 		log.WithField("names", names).Debug("using names")
-		return names, pattern
 	}
-	first := args[0]
-	if rest, found := strings.CutPrefix(first, Re2Prefix); found {
-		pattern = rest
+	if pattern != "" {
 		log.WithField("pattern", pattern).Debug("using pattern")
-		return names, pattern
 	}
-	names = append(names, first)
-	log.WithField("names", names).Debug("using names")
 	return names, pattern
+}
+
+// joinPatterns creates a regular-expression union while preserving each
+// selector's boundaries. A single pattern is left untouched for compatibility.
+func joinPatterns(patterns []string) string {
+	switch len(patterns) {
+	case 0:
+		return ""
+	case 1:
+		return patterns[0]
+	default:
+		return "(" + strings.Join(patterns, ")|(") + ")"
+	}
 }
 
 // RunChaosCommand run chaos command in go routine

--- a/pkg/chaos/command_test.go
+++ b/pkg/chaos/command_test.go
@@ -176,6 +176,18 @@ func TestGetNamesOrPattern(t *testing.T) {
 			wantNames:   nil,
 			wantPattern: "",
 		},
+		{
+			name:        "multiple re2 patterns preserve selector boundaries",
+			args:        []string{"re2:^web$", "re2:^api$"},
+			wantNames:   nil,
+			wantPattern: "(^web$)|(^api$)",
+		},
+		{
+			name:        "mixed exact names and re2 patterns",
+			args:        []string{"re2:^web-", "database", "re2:^api-"},
+			wantNames:   []string{"database"},
+			wantPattern: "(^web-)|(^api-)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/container/filter.go
+++ b/pkg/container/filter.go
@@ -41,10 +41,12 @@ func applyContainerFilter(flt filter) FilterFunc {
 		if c.IsPumba() || c.IsPumbaSkip() {
 			return false
 		}
-		// match names
-		if len(flt.Names) > 0 {
-			return matchNames(flt.Names, c.ContainerName, c.ContainerID)
+		// Exact names and RE2 patterns are alternative selectors. Evaluating both
+		// allows mixed positional arguments to use the same selection path.
+		if len(flt.Names) == 0 {
+			return matchPattern(flt.Pattern, c.ContainerName)
 		}
-		return matchPattern(flt.Pattern, c.ContainerName)
+		return matchNames(flt.Names, c.ContainerName, c.ContainerID) ||
+			(flt.Pattern != "" && matchPattern(flt.Pattern, c.ContainerName))
 	}
 }

--- a/pkg/container/filter_test.go
+++ b/pkg/container/filter_test.go
@@ -169,6 +169,36 @@ func TestApplyContainerFilter(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "matches exact selector when patterns are also present",
+			container: &Container{
+				ContainerName: "database",
+				Labels:        map[string]string{},
+				Networks:      map[string]NetworkLink{},
+			},
+			filter:   filter{Names: []string{"database"}, Pattern: "(^web$)|(^api$)"},
+			expected: true,
+		},
+		{
+			name: "matches regex selector when exact names are also present",
+			container: &Container{
+				ContainerName: "api",
+				Labels:        map[string]string{},
+				Networks:      map[string]NetworkLink{},
+			},
+			filter:   filter{Names: []string{"database"}, Pattern: "(^web$)|(^api$)"},
+			expected: true,
+		},
+		{
+			name: "preserves regex selector boundaries",
+			container: &Container{
+				ContainerName: "web-1",
+				Labels:        map[string]string{},
+				Networks:      map[string]NetworkLink{},
+			},
+			filter:   filter{Names: []string{"database"}, Pattern: "(^web$)|(^api$)"},
+			expected: false,
+		},
+		{
 			name: "excludes non-target with all flag",
 			container: &Container{
 				ContainerName: "other",

--- a/tests/multi_container.bats
+++ b/tests/multi_container.bats
@@ -51,6 +51,25 @@ teardown() {
 }
 
 
+@test "Should combine exact names and multiple regex selectors" {
+    create_test_container "multi_test_web_1"
+    create_test_container "multi_test_api_1"
+    create_test_container "multi_test_exact"
+    create_test_container "multi_test_other_1"
+
+    run pumba stop "re2:^multi_test_web_" multi_test_exact "re2:^multi_test_api_"
+    assert_success
+
+    for name in multi_test_web_1 multi_test_api_1 multi_test_exact; do
+        run docker inspect -f {{.State.Status}} "$name"
+        assert_output "exited"
+    done
+
+    run docker inspect -f {{.State.Status}} multi_test_other_1
+    assert_output "running"
+}
+
+
 @test "Should only affect containers with matching labels" {
     # Given multiple containers with different labels
     # Create containers with label test=true


### PR DESCRIPTION
## Summary
- support multiple `re2:` container selectors alongside exact names
- preserve exported `chaos.GlobalParams.Pattern` by compiling selector regexes into its canonical pattern
- document mixed selector usage and cover exact, regex, and boundary matching

Supersedes #328.

Closes #179.

## Validation
- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go build -o /tmp/pumba-issue179 ./cmd`
- `golangci-lint run -c .golangci.yaml ./cmd`, `./pkg/chaos`, and `./pkg/container`