### PR TITLE
fix: preserve empty regex selector semantics

### DIFF
--- a/pkg/chaos/command.go
+++ b/pkg/chaos/command.go
@@ -85,6 +85,11 @@ func getNamesOrPattern(c cliflags.Flags) ([]string, string) {
 	}
 
 	pattern := joinPatterns(patterns)
+	if len(names) > 0 && len(patterns) == 1 && patterns[0] == "" {
+		// Preserve the empty RE2 selector's match-all semantics when it is mixed
+		// with exact names. An empty Pattern means "no pattern" to the filter.
+		pattern = "()"
+	}
 	if len(names) > 0 {
 		log.WithField("names", names).Debug("using names")
 	}

--- a/pkg/chaos/command_test.go
+++ b/pkg/chaos/command_test.go
@@ -188,6 +188,12 @@ func TestGetNamesOrPattern(t *testing.T) {
 			wantNames:   []string{"database"},
 			wantPattern: "(^web-)|(^api-)",
 		},
+		{
+			name:        "empty re2 preserves match-all when mixed with exact name",
+			args:        []string{"re2:", "database"},
+			wantNames:   []string{"database"},
+			wantPattern: "()",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/container/filter_test.go
+++ b/pkg/container/filter_test.go
@@ -189,6 +189,16 @@ func TestApplyContainerFilter(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "empty regex selector matches all eligible containers with exact names",
+			container: &Container{
+				ContainerName: "other",
+				Labels:        map[string]string{},
+				Networks:      map[string]NetworkLink{},
+			},
+			filter:   filter{Names: []string{"database"}, Pattern: "()"},
+			expected: true,
+		},
+		{
 			name: "preserves regex selector boundaries",
 			container: &Container{
 				ContainerName: "web-1",

--- a/tests/multi_container.bats
+++ b/tests/multi_container.bats
@@ -70,6 +70,20 @@ teardown() {
 }
 
 
+@test "Should preserve empty regex match-all with an exact selector" {
+    create_test_container "multi_test_exact_empty_re2"
+    create_test_container "multi_test_other_empty_re2"
+
+    run pumba stop "re2:" multi_test_exact_empty_re2
+    assert_success
+
+    for name in multi_test_exact_empty_re2 multi_test_other_empty_re2; do
+        run docker inspect -f {{.State.Status}} "$name"
+        assert_output "exited"
+    done
+}
+
+
 @test "Should only affect containers with matching labels" {
     # Given multiple containers with different labels
     # Create containers with label test=true


### PR DESCRIPTION
## Summary

- preserve a bare `re2:` selector when combined with exact names
- add parser and filter regression coverage
- add a Docker Bats regression proving the empty selector still matches all eligible containers

Follow-up to #348.

Fixes the Medium correctness finding: `re2:` plus an exact name previously dropped the empty regex because an empty `Pattern` also means no pattern in the filter. The fix encodes the mixed empty selector as `()` while preserving existing no-argument and standalone `re2:` behavior.