### PR TITLE
feat(netem): resolve container names in target filters

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -35,7 +35,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 				cli.StringSliceFlag{
 					Name:  "target, t",
-					Usage: "target filter; supports multiple values; accepts IPs, CIDR notation, or a running container name/ID (resolved to its IP address(es) at run time)",
+					Usage: "target filter; repeatable IPv4/CIDR or running container name/ID; IPv6 is not supported",
 				},
 				cli.StringFlag{
 					Name:  "egress-port, egressPort",

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -35,7 +35,7 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 				},
 				cli.StringSliceFlag{
 					Name:  "target, t",
-					Usage: "target IP filter; supports multiple IPs; supports CIDR notation",
+					Usage: "target filter; supports multiple values; accepts IPs, CIDR notation, or a running container name/ID (resolved to its IP address(es) at run time)",
 				},
 				cli.StringFlag{
 					Name:  "egress-port, egressPort",

--- a/docs/network-chaos.md
+++ b/docs/network-chaos.md
@@ -81,7 +81,7 @@ Network emulation (`netem`) manipulates **outgoing** traffic using Linux traffic
 | ------------------------------- | ------------------------------------------------------ | ------------------------------------------------- |
 | `--duration`, `-d`              | Emulation duration (must be shorter than `--interval`) | required                                          |
 | `--interface`, `-i`             | Network interface to apply rules on                    | `eth0`                                            |
-| `--target`, `-t`                | Target filter (repeatable); IP, CIDR, or container name/ID | all                                           |
+| `--target`, `-t`                | Target filter (repeatable); IPv4, CIDR, or container name/ID | all                                          |
 | `--egress-port`, `egressPort`   | Egress (source) port filter (comma-separated)          | all                                               |
 | `--ingress-port`, `ingressPort` | Ingress (destination) port filter (comma-separated)    | all                                               |
 | `--tc-image`                    | Docker image with `tc` tool                            | `ghcr.io/alexei-led/pumba-alpine-nettools:latest` |
@@ -89,12 +89,13 @@ Network emulation (`netem`) manipulates **outgoing** traffic using Linux traffic
 
 Run `pumba netem --help` for the full list of options.
 
-`--target` accepts an IP address, CIDR block, or a running container's name
+`--target` accepts an IPv4 address, CIDR block, or a running container's name
 or ID — mix and match, and repeat the flag for multiple values. A container
-name/ID is resolved to that container's IP address(es) when the command
-runs: if the container is attached to more than one network, every address
-it has is added as a separate filter, so traffic to/from any of them is
-affected. Resolution requires an unambiguous match — a name or ID prefix
+name/ID is resolved on every command run, including each interval run. If the
+container is attached to more than one network, every IPv4 address is added as
+a separate filter, so traffic to/from any of them is affected. IPv6 targets
+fail explicitly because netem's current filter planner emits IPv4 rules only.
+Resolution requires an unambiguous match — a name or ID prefix
 that matches more than one running container is a hard error rather than an
 arbitrary pick — and a value that is neither a valid IP/CIDR nor a
 resolvable container name/ID also fails with a clear error instead of

--- a/docs/network-chaos.md
+++ b/docs/network-chaos.md
@@ -81,13 +81,29 @@ Network emulation (`netem`) manipulates **outgoing** traffic using Linux traffic
 | ------------------------------- | ------------------------------------------------------ | ------------------------------------------------- |
 | `--duration`, `-d`              | Emulation duration (must be shorter than `--interval`) | required                                          |
 | `--interface`, `-i`             | Network interface to apply rules on                    | `eth0`                                            |
-| `--target`, `-t`                | Target IP filter (repeatable); supports CIDR notation  | all                                               |
+| `--target`, `-t`                | Target filter (repeatable); IP, CIDR, or container name/ID | all                                           |
 | `--egress-port`, `egressPort`   | Egress (source) port filter (comma-separated)          | all                                               |
 | `--ingress-port`, `ingressPort` | Ingress (destination) port filter (comma-separated)    | all                                               |
 | `--tc-image`                    | Docker image with `tc` tool                            | `ghcr.io/alexei-led/pumba-alpine-nettools:latest` |
 | `--pull-image`                  | Force pull the tc-image                                | `true`                                            |
 
 Run `pumba netem --help` for the full list of options.
+
+`--target` accepts an IP address, CIDR block, or a running container's name
+or ID — mix and match, and repeat the flag for multiple values. A container
+name/ID is resolved to that container's IP address(es) when the command
+runs: if the container is attached to more than one network, every address
+it has is added as a separate filter, so traffic to/from any of them is
+affected. Resolution requires an unambiguous match — a name or ID prefix
+that matches more than one running container is a hard error rather than an
+arbitrary pick — and a value that is neither a valid IP/CIDR nor a
+resolvable container name/ID also fails with a clear error instead of
+silently matching nothing.
+
+```bash
+# Delay only traffic to/from container "service-b" (resolved to its IP)
+pumba netem --duration 10m --target service-b delay --time 1000 service-a
+```
 
 ### delay
 
@@ -287,8 +303,9 @@ Test how services handle degraded inter-service communication:
 
 ```bash
 # High latency between service-a and service-b
+# --target accepts an IP/CIDR or, as here, a container name/ID to resolve
 pumba netem --tc-image ghcr.io/alexei-led/pumba-alpine-nettools:latest \
-    --target service-b-ip --duration 10m \
+    --target service-b --duration 10m \
     delay --time 1000 --jitter 200 service-a &
 
 # Packet loss from service-c to service-b

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -59,6 +59,12 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -62,7 +62,8 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -71,7 +72,7 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": c}).Debug("adding network random packet corrupt for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -77,6 +77,12 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -80,7 +80,8 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -89,7 +90,7 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": c}).Debug("adding network delay for container")
 			netemCtx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -149,6 +149,75 @@ func TestDelayCommand_Run_WithRandom(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestDelayCommand_Run_TargetContainerNameResolvedOnce(t *testing.T) {
+	// gp.Names matches two containers, so the netem delay loop below runs
+	// twice — but --target names a third container to resolve, and that
+	// resolution must happen exactly once per command invocation, not once
+	// per matched container.
+	mockClient := container.NewMockClient(t)
+	peer := &container.Container{
+		ContainerID:   "peerid",
+		ContainerName: "/peer",
+		Networks:      map[string]container.NetworkLink{"bridge": {IPv4Address: "10.5.0.9"}},
+	}
+	c1 := &container.Container{ContainerID: "id1", ContainerName: "c1", Networks: map[string]container.NetworkLink{}}
+	c2 := &container.Container{ContainerID: "id2", ContainerName: "c2", Networks: map[string]container.NetworkLink{}}
+
+	gparams := &chaos.GlobalParams{Names: []string{"c1", "c2"}, DryRun: true}
+	nparams := &container.NetemRequest{
+		Interface:   "eth0",
+		Duration:    100 * time.Millisecond,
+		Sidecar:     container.SidecarSpec{Image: "tc"},
+		DryRun:      true,
+		TargetNames: []string{"peer"},
+	}
+
+	// First call: resolveTargetNames looking up "peer".
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{peer}, nil).Once()
+	// Second call: chaos.RunOnContainers listing containers matching gp.Names.
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{c1, c2}, nil).Once()
+
+	mockClient.EXPECT().NetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
+	mockClient.EXPECT().StopNetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
+
+	cmd, err := NewDelayCommand(mockClient, gparams, nparams, 0, 100, 0, 0, "")
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), false)
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+	assert.Empty(t, nparams.TargetNames, "TargetNames must be resolved and cleared")
+	require.Len(t, nparams.IPs, 1)
+	assert.Equal(t, "10.5.0.9/32", nparams.IPs[0].String())
+}
+
+func TestDelayCommand_Run_TargetContainerNameNotFound(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	gparams := &chaos.GlobalParams{Names: []string{"c1"}, DryRun: true}
+	nparams := &container.NetemRequest{
+		Interface:   "eth0",
+		Duration:    100 * time.Millisecond,
+		DryRun:      true,
+		TargetNames: []string{"ghost"},
+	}
+
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
+		Return([]*container.Container{}, nil)
+
+	cmd, err := NewDelayCommand(mockClient, gparams, nparams, 0, 100, 0, 0, "")
+	require.NoError(t, err)
+
+	err = cmd.Run(context.Background(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+	mockClient.AssertExpectations(t)
+}
+
 func TestDelayCommand_Run_DryRun(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -181,7 +181,10 @@ func TestDelayCommand_Run_TargetContainerNameResolvedOnce(t *testing.T) {
 		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false, Labels: nil}).
 		Return([]*container.Container{c1, c2}, nil).Once()
 
-	mockClient.EXPECT().NetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
+	resolvedRequest := mock.MatchedBy(func(req *container.NetemRequest) bool {
+		return len(req.IPs) == 1 && req.IPs[0].String() == "10.5.0.9/32" && len(req.TargetNames) == 0
+	})
+	mockClient.EXPECT().NetemContainer(mock.Anything, resolvedRequest).Return(nil).Twice()
 	mockClient.EXPECT().StopNetemContainer(mock.Anything, mock.AnythingOfType("*container.NetemRequest")).Return(nil).Twice()
 
 	cmd, err := NewDelayCommand(mockClient, gparams, nparams, 0, 100, 0, 0, "")
@@ -190,9 +193,8 @@ func TestDelayCommand_Run_TargetContainerNameResolvedOnce(t *testing.T) {
 	err = cmd.Run(context.Background(), false)
 	assert.NoError(t, err)
 	mockClient.AssertExpectations(t)
-	assert.Empty(t, nparams.TargetNames, "TargetNames must be resolved and cleared")
-	require.Len(t, nparams.IPs, 1)
-	assert.Equal(t, "10.5.0.9/32", nparams.IPs[0].String())
+	assert.Equal(t, []string{"peer"}, nparams.TargetNames, "the next interval must resolve the target again")
+	assert.Empty(t, nparams.IPs)
 }
 
 func TestDelayCommand_Run_TargetContainerNameNotFound(t *testing.T) {

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -66,7 +66,8 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -75,7 +76,7 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": c}).Debug("adding network random packet duplicates for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -63,6 +63,12 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -58,6 +58,12 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -61,7 +61,8 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -70,7 +71,7 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": *c}).Debug("adding network random packet loss for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -74,6 +74,12 @@ func (n *lossGECommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/loss_ge.go
+++ b/pkg/chaos/netem/loss_ge.go
@@ -77,7 +77,8 @@ func (n *lossGECommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -86,7 +87,7 @@ func (n *lossGECommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": c}).Debug("adding network random packet loss for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -84,7 +84,8 @@ func (n *lossStateCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -93,7 +94,7 @@ func (n *lossStateCommand) Run(ctx context.Context, random bool) error {
 			log.WithFields(log.Fields{"container": c}).Debug("adding network 4-state packet loss for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/loss_state.go
+++ b/pkg/chaos/netem/loss_state.go
@@ -81,6 +81,12 @@ func (n *lossStateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/netem.go
+++ b/pkg/chaos/netem/netem.go
@@ -13,6 +13,7 @@ import (
 // netemClient is the narrow interface needed by all netem commands.
 type netemClient interface {
 	container.Lister
+	container.AddressResolver
 	container.Netem
 }
 

--- a/pkg/chaos/netem/netem.go
+++ b/pkg/chaos/netem/netem.go
@@ -23,6 +23,16 @@ const cleanupTimeout = 30 * time.Second
 
 // run network emulation command, stop netem on timeout or abort
 func runNetem(ctx context.Context, client netemClient, req *container.NetemRequest) error {
+	// Each per-action Run already resolves --target container names/IDs
+	// once, before matched containers are enumerated (see e.g. delay.go).
+	// This call is a no-op then, since TargetNames is already empty; it
+	// only does real work if runNetem is ever called directly with an
+	// unresolved request, so req.IPs is always complete by the time it's
+	// handed to the runtime client below.
+	if err := resolveTargetNames(ctx, client, req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
+
 	logger := log.WithFields(log.Fields{
 		"id":       req.Container.ID(),
 		"name":     req.Container.Name(),

--- a/pkg/chaos/netem/parse.go
+++ b/pkg/chaos/netem/parse.go
@@ -21,8 +21,8 @@ import (
 // Each --target value is parsed as an IP or CIDR literal first; values that
 // aren't (e.g. a container name or ID) are kept as-is in TargetNames rather
 // than rejected here, since resolving them requires a runtime client that
-// isn't available during CLI flag parsing. runNetem resolves TargetNames
-// into IPs the first time the command actually runs — see netem.go.
+// isn't available during CLI flag parsing. Each command Run resolves
+// TargetNames into IPv4 filters before enumerating affected containers.
 //
 // c must be the netem parent context. Per-action parsers pass c.Parent().
 func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.NetemRequest, int, error) {
@@ -47,6 +47,9 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 			// resolve later, once a runtime client is available.
 			targetNames = append(targetNames, s)
 			continue
+		}
+		if ip.IP.To4() == nil {
+			return nil, 0, fmt.Errorf("IPv6 --target %q is not supported", s)
 		}
 		ips = append(ips, ip)
 	}

--- a/pkg/chaos/netem/parse.go
+++ b/pkg/chaos/netem/parse.go
@@ -39,6 +39,7 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 	}
 	targetList := c.StringSlice("target")
 	ips := make([]*net.IPNet, 0, len(targetList))
+	seenIPs := make(map[string]struct{}, len(targetList))
 	var targetNames []string
 	for _, s := range targetList {
 		ip, err := util.ParseCIDR(s)
@@ -51,6 +52,10 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 		if ip.IP.To4() == nil {
 			return nil, 0, fmt.Errorf("IPv6 --target %q is not supported", s)
 		}
+		if _, ok := seenIPs[ip.String()]; ok {
+			continue
+		}
+		seenIPs[ip.String()] = struct{}{}
 		ips = append(ips, ip)
 	}
 	sports, err := util.GetPorts(c.String("egress-port"))

--- a/pkg/chaos/netem/parse.go
+++ b/pkg/chaos/netem/parse.go
@@ -18,6 +18,12 @@ import (
 // rather than by the runtime). Container and Command are left zero — each
 // per-action Run sets them per iteration.
 //
+// Each --target value is parsed as an IP or CIDR literal first; values that
+// aren't (e.g. a container name or ID) are kept as-is in TargetNames rather
+// than rejected here, since resolving them requires a runtime client that
+// isn't available during CLI flag parsing. runNetem resolves TargetNames
+// into IPs the first time the command actually runs — see netem.go.
+//
 // c must be the netem parent context. Per-action parsers pass c.Parent().
 func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.NetemRequest, int, error) {
 	duration := c.Duration("duration")
@@ -31,12 +37,16 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 	if err := util.ValidateInterfaceName(iface); err != nil {
 		return nil, 0, err
 	}
-	ipsList := c.StringSlice("target")
-	ips := make([]*net.IPNet, 0, len(ipsList))
-	for _, s := range ipsList {
+	targetList := c.StringSlice("target")
+	ips := make([]*net.IPNet, 0, len(targetList))
+	var targetNames []string
+	for _, s := range targetList {
 		ip, err := util.ParseCIDR(s)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to parse ip: %w", err)
+			// Not a literal IP/CIDR — treat as a container name or ID to
+			// resolve later, once a runtime client is available.
+			targetNames = append(targetNames, s)
+			continue
 		}
 		ips = append(ips, ip)
 	}
@@ -49,12 +59,13 @@ func ParseRequestBase(c cliflags.Flags, gp *chaos.GlobalParams) (*container.Nete
 		return nil, 0, fmt.Errorf("failed to get destination ports: %w", err)
 	}
 	return &container.NetemRequest{
-		Interface: iface,
-		IPs:       ips,
-		SPorts:    sports,
-		DPorts:    dports,
-		Duration:  duration,
-		Sidecar:   container.SidecarSpec{Image: c.String("tc-image"), Pull: c.Bool("pull-image")},
-		DryRun:    gp.DryRun,
+		Interface:   iface,
+		IPs:         ips,
+		TargetNames: targetNames,
+		SPorts:      sports,
+		DPorts:      dports,
+		Duration:    duration,
+		Sidecar:     container.SidecarSpec{Image: c.String("tc-image"), Pull: c.Bool("pull-image")},
+		DryRun:      gp.DryRun,
 	}, c.Int("limit"), nil
 }

--- a/pkg/chaos/netem/parse_test.go
+++ b/pkg/chaos/netem/parse_test.go
@@ -128,6 +128,20 @@ func TestParseRequestBase_PortsAndIPsParsed(t *testing.T) {
 	assert.Equal(t, []string{"8080"}, req.DPorts)
 }
 
+func TestParseRequestBase_DeduplicatesEquivalentIPv4Targets(t *testing.T) {
+	c := cliflags.NewV1(parentCtx(t, []string{
+		"--duration", "1s", "--interface", "eth0",
+		"--target", "10.0.0.1",
+		"--target", "10.0.0.1/32",
+	}))
+
+	req, _, err := ParseRequestBase(c, &chaos.GlobalParams{})
+
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.1/32", req.IPs[0].String())
+}
+
 func TestParseRequestBase_RejectsIPv6Target(t *testing.T) {
 	c := cliflags.NewV1(parentCtx(t, []string{
 		"--duration", "1s", "--interface", "eth0",

--- a/pkg/chaos/netem/parse_test.go
+++ b/pkg/chaos/netem/parse_test.go
@@ -128,6 +128,19 @@ func TestParseRequestBase_PortsAndIPsParsed(t *testing.T) {
 	assert.Equal(t, []string{"8080"}, req.DPorts)
 }
 
+func TestParseRequestBase_RejectsIPv6Target(t *testing.T) {
+	c := cliflags.NewV1(parentCtx(t, []string{
+		"--duration", "1s", "--interface", "eth0",
+		"--target", "fd00::5",
+	}))
+
+	_, _, err := ParseRequestBase(c, &chaos.GlobalParams{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv6")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
 func TestParseRequestBase_TargetContainerNamesDeferred(t *testing.T) {
 	// Values that aren't valid IP/CIDR literals are not rejected at parse
 	// time — no runtime client is available yet to check whether they name

--- a/pkg/chaos/netem/parse_test.go
+++ b/pkg/chaos/netem/parse_test.go
@@ -73,12 +73,6 @@ func TestParseRequestBase(t *testing.T) {
 			wantErr: "bad network interface name",
 		},
 		{
-			name:    "invalid CIDR rejected",
-			args:    []string{"--duration", "1s", "--interface", "eth0", "--target", "not-a-cidr"},
-			gp:      &chaos.GlobalParams{},
-			wantErr: "failed to parse ip",
-		},
-		{
 			name:    "invalid egress port rejected",
 			args:    []string{"--duration", "1s", "--interface", "eth0", "--egress-port", "abc"},
 			gp:      &chaos.GlobalParams{},
@@ -129,6 +123,25 @@ func TestParseRequestBase_PortsAndIPsParsed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, req.IPs, 1)
 	assert.Equal(t, "10.0.0.0/24", req.IPs[0].String())
+	assert.Empty(t, req.TargetNames)
 	assert.Equal(t, []string{"80", "443"}, req.SPorts)
 	assert.Equal(t, []string{"8080"}, req.DPorts)
+}
+
+func TestParseRequestBase_TargetContainerNamesDeferred(t *testing.T) {
+	// Values that aren't valid IP/CIDR literals are not rejected at parse
+	// time — no runtime client is available yet to check whether they name
+	// a real container. They're kept as candidates in TargetNames and
+	// resolved later, once a client exists (see resolveTargetNames).
+	c := cliflags.NewV1(parentCtx(t, []string{
+		"--duration", "1s", "--interface", "eth0",
+		"--target", "10.0.0.5",
+		"--target", "web-1",
+		"--target", "db",
+	}))
+	req, _, err := ParseRequestBase(c, &chaos.GlobalParams{})
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.5/32", req.IPs[0].String())
+	assert.Equal(t, []string{"web-1", "db"}, req.TargetNames)
 }

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -83,7 +83,8 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 	// Resolve --target container names/IDs once per command invocation,
 	// before containers are enumerated, rather than once per matched
 	// container inside the loop below.
-	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
 		return fmt.Errorf("failed to resolve --target: %w", err)
 	}
 	netemCmd := n.buildNetemCmd()
@@ -95,7 +96,7 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 			}).Debug("setting network rate for container")
 			netemCtx, cancel := context.WithTimeout(ctx, n.req.Duration)
 			defer cancel()
-			req := *n.req
+			req := *resolvedReq
 			req.Container = c
 			req.Command = netemCmd
 			if err := runNetem(netemCtx, n.client, &req); err != nil {

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -80,6 +80,12 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 		"limit":   n.limit,
 		"random":  random,
 	}).Debug("listing matching containers")
+	// Resolve --target container names/IDs once per command invocation,
+	// before containers are enumerated, rather than once per matched
+	// container inside the loop below.
+	if err := resolveTargetNames(ctx, n.client, n.req); err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
 	netemCmd := n.buildNetemCmd()
 	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
 		func(ctx context.Context, c *container.Container) error {

--- a/pkg/chaos/netem/target.go
+++ b/pkg/chaos/netem/target.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/alexei-led/pumba/pkg/container"
@@ -22,11 +23,9 @@ const minIDPrefixLen = 6
 // no-op — no runtime call at all — when TargetNames is empty, so plain
 // IP/CIDR --target usage, the overwhelming common case, costs nothing extra.
 //
-// Each name/ID is matched against currently running containers, in order:
-//  1. exact container name (Docker/Podman report names with a leading "/",
-//     which is trimmed before comparing);
-//  2. exact container ID;
-//  3. a unique container-ID prefix of at least minIDPrefixLen characters.
+// Each name/ID is matched against currently running containers by exact
+// container name or ID first, then by a unique container-ID prefix of at least
+// minIDPrefixLen characters. Docker/Podman's leading name slash is ignored.
 //
 // A target that matches more than one container at the same priority level
 // is a hard error rather than an arbitrary pick: silently applying a network
@@ -35,45 +34,80 @@ const minIDPrefixLen = 6
 // attached network (e.g. host networking, or a runtime that doesn't report
 // one), is also a hard error — never a silent no-op.
 //
-// A resolved container contributes every IPv4 address found across all of
-// its attached networks: a container connected to more than one network is
-// reachable on each of those addresses, and tc needs a filter per address to
-// actually scope traffic to all of them rather than just one arbitrarily
-// chosen network.
-func resolveTargetNames(ctx context.Context, lister container.Lister, req *container.NetemRequest) error {
+// A resolved container contributes every IPv4 address reported by its
+// runtime. IPv6 targets fail explicitly because the current tc filter planner
+// only emits protocol-ip rules.
+type targetResolver interface {
+	container.Lister
+	container.AddressResolver
+}
+
+func resolveRequestTargets(ctx context.Context, resolver targetResolver, source *container.NetemRequest) (*container.NetemRequest, error) {
+	req := *source
+	req.IPs = slices.Clone(source.IPs)
+	req.TargetNames = slices.Clone(source.TargetNames)
+	if err := resolveTargetNames(ctx, resolver, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func resolveTargetNames(ctx context.Context, resolver targetResolver, req *container.NetemRequest) error {
 	if len(req.TargetNames) == 0 {
 		return nil
 	}
-	candidates, err := lister.ListContainers(ctx, func(*container.Container) bool { return true }, container.ListOpts{All: false})
+	candidates, err := resolver.ListContainers(ctx, func(*container.Container) bool { return true }, container.ListOpts{All: false})
 	if err != nil {
 		return fmt.Errorf("failed to list containers while resolving --target: %w", err)
 	}
+	seen := make(map[string]struct{}, len(req.IPs))
+	for _, ip := range req.IPs {
+		seen[ip.String()] = struct{}{}
+	}
+	resolved := make([]*net.IPNet, 0, len(req.TargetNames))
+	addressCache := make(map[string][]net.IP)
 	for _, name := range req.TargetNames {
 		c, err := matchTargetContainer(name, candidates)
 		if err != nil {
 			return err
 		}
-		ips := c.IPs()
-		if len(ips) == 0 {
+		addresses, ok := addressCache[c.ID()]
+		if !ok {
+			addresses = c.IPs()
+			if len(addresses) == 0 {
+				addresses, err = resolver.ContainerAddresses(ctx, c)
+				if err != nil {
+					return fmt.Errorf("failed to resolve addresses for --target %q container %q (%s): %w", name, c.Name(), c.ID(), err)
+				}
+			}
+			addressCache[c.ID()] = addresses
+		}
+		if len(addresses) == 0 {
 			return fmt.Errorf("--target %q resolved to container %q (%s) but it has no IP address on any attached network",
 				name, c.Name(), c.ID())
 		}
-		for _, ip := range ips {
-			req.IPs = append(req.IPs, hostCIDR(ip))
+		for _, address := range addresses {
+			ipv4 := address.To4()
+			if ipv4 == nil {
+				return fmt.Errorf("--target %q resolved to unsupported IPv6 address %s; IPv6 netem filters are not supported", name, address)
+			}
+			cidr := hostCIDR(ipv4)
+			if _, ok := seen[cidr.String()]; ok {
+				continue
+			}
+			seen[cidr.String()] = struct{}{}
+			resolved = append(resolved, cidr)
 		}
 	}
+	req.IPs = append(req.IPs, resolved...)
 	req.TargetNames = nil
 	return nil
 }
 
-// hostCIDR wraps a single resolved address as a host route (/32 for IPv4,
-// /128 for IPv6), matching how util.ParseCIDR treats a bare IP given
-// directly on --target.
+// hostCIDR wraps a resolved IPv4 address as a host route, matching how
+// util.ParseCIDR treats a bare IP passed directly to --target.
 func hostCIDR(ip net.IP) *net.IPNet {
-	if v4 := ip.To4(); v4 != nil {
-		return &net.IPNet{IP: v4, Mask: net.CIDRMask(32, 32)} //nolint:mnd
-	}
-	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)} //nolint:mnd
+	return &net.IPNet{IP: ip.To4(), Mask: net.CIDRMask(32, 32)} //nolint:mnd
 }
 
 // matchTargetContainer resolves a single --target value against the
@@ -85,26 +119,27 @@ func matchTargetContainer(target string, candidates []*container.Container) (*co
 		return nil, fmt.Errorf("--target %q is not a valid IP/CIDR or container name/ID", target)
 	}
 
-	var byName, byID, byIDPrefix []*container.Container
+	exact := make(map[*container.Container]struct{})
+	var byIDPrefix []*container.Container
 	for _, c := range candidates {
-		if strings.TrimPrefix(c.Name(), "/") == trimmedTarget {
-			byName = append(byName, c)
+		if strings.TrimPrefix(c.Name(), "/") == trimmedTarget || c.ID() == target {
+			exact[c] = struct{}{}
+			continue
 		}
-		switch {
-		case c.ID() == target:
-			byID = append(byID, c)
-		case len(target) >= minIDPrefixLen && strings.HasPrefix(c.ID(), target):
+		if len(target) >= minIDPrefixLen && strings.HasPrefix(c.ID(), target) {
 			byIDPrefix = append(byIDPrefix, c)
 		}
 	}
 
 	switch {
-	case len(byName) == 1:
-		return byName[0], nil
-	case len(byName) > 1:
-		return nil, fmt.Errorf("--target %q is ambiguous: matches %d container names", target, len(byName))
-	case len(byID) == 1:
-		return byID[0], nil
+	case len(exact) == 1:
+		var match *container.Container
+		for c := range exact {
+			match = c
+		}
+		return match, nil
+	case len(exact) > 1:
+		return nil, fmt.Errorf("--target %q is ambiguous: matches %d exact container names or IDs", target, len(exact))
 	case len(byIDPrefix) == 1:
 		return byIDPrefix[0], nil
 	case len(byIDPrefix) > 1:

--- a/pkg/chaos/netem/target.go
+++ b/pkg/chaos/netem/target.go
@@ -1,0 +1,115 @@
+package netem
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/alexei-led/pumba/pkg/container"
+)
+
+// minIDPrefixLen is the shortest container-ID prefix resolveTargetNames will
+// try to match. Docker's own short IDs are 12 characters; anything much
+// shorter has a real chance of prefix-colliding with an unrelated container
+// in a large fleet, so target names shorter than this are only tried
+// against exact container names, never against ID prefixes.
+const minIDPrefixLen = 6
+
+// resolveTargetNames resolves req.TargetNames — --target values that were
+// not valid IP/CIDR literals at parse time (see ParseRequestBase) — into IP
+// filters, appending the result to req.IPs and clearing TargetNames. It is a
+// no-op — no runtime call at all — when TargetNames is empty, so plain
+// IP/CIDR --target usage, the overwhelming common case, costs nothing extra.
+//
+// Each name/ID is matched against currently running containers, in order:
+//  1. exact container name (Docker/Podman report names with a leading "/",
+//     which is trimmed before comparing);
+//  2. exact container ID;
+//  3. a unique container-ID prefix of at least minIDPrefixLen characters.
+//
+// A target that matches more than one container at the same priority level
+// is a hard error rather than an arbitrary pick: silently applying a network
+// filter to the wrong container's IP is worse than refusing to run. A target
+// that matches no container, or a container with no IP address on any
+// attached network (e.g. host networking, or a runtime that doesn't report
+// one), is also a hard error — never a silent no-op.
+//
+// A resolved container contributes every IPv4 address found across all of
+// its attached networks: a container connected to more than one network is
+// reachable on each of those addresses, and tc needs a filter per address to
+// actually scope traffic to all of them rather than just one arbitrarily
+// chosen network.
+func resolveTargetNames(ctx context.Context, lister container.Lister, req *container.NetemRequest) error {
+	if len(req.TargetNames) == 0 {
+		return nil
+	}
+	candidates, err := lister.ListContainers(ctx, func(*container.Container) bool { return true }, container.ListOpts{All: false})
+	if err != nil {
+		return fmt.Errorf("failed to list containers while resolving --target: %w", err)
+	}
+	for _, name := range req.TargetNames {
+		c, err := matchTargetContainer(name, candidates)
+		if err != nil {
+			return err
+		}
+		ips := c.IPs()
+		if len(ips) == 0 {
+			return fmt.Errorf("--target %q resolved to container %q (%s) but it has no IP address on any attached network",
+				name, c.Name(), c.ID())
+		}
+		for _, ip := range ips {
+			req.IPs = append(req.IPs, hostCIDR(ip))
+		}
+	}
+	req.TargetNames = nil
+	return nil
+}
+
+// hostCIDR wraps a single resolved address as a host route (/32 for IPv4,
+// /128 for IPv6), matching how util.ParseCIDR treats a bare IP given
+// directly on --target.
+func hostCIDR(ip net.IP) *net.IPNet {
+	if v4 := ip.To4(); v4 != nil {
+		return &net.IPNet{IP: v4, Mask: net.CIDRMask(32, 32)} //nolint:mnd
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)} //nolint:mnd
+}
+
+// matchTargetContainer resolves a single --target value against the
+// candidate container list. See resolveTargetNames for the matching order
+// and ambiguity rules.
+func matchTargetContainer(target string, candidates []*container.Container) (*container.Container, error) {
+	trimmedTarget := strings.TrimPrefix(target, "/")
+	if trimmedTarget == "" {
+		return nil, fmt.Errorf("--target %q is not a valid IP/CIDR or container name/ID", target)
+	}
+
+	var byName, byID, byIDPrefix []*container.Container
+	for _, c := range candidates {
+		if strings.TrimPrefix(c.Name(), "/") == trimmedTarget {
+			byName = append(byName, c)
+		}
+		switch {
+		case c.ID() == target:
+			byID = append(byID, c)
+		case len(target) >= minIDPrefixLen && strings.HasPrefix(c.ID(), target):
+			byIDPrefix = append(byIDPrefix, c)
+		}
+	}
+
+	switch {
+	case len(byName) == 1:
+		return byName[0], nil
+	case len(byName) > 1:
+		return nil, fmt.Errorf("--target %q is ambiguous: matches %d container names", target, len(byName))
+	case len(byID) == 1:
+		return byID[0], nil
+	case len(byIDPrefix) == 1:
+		return byIDPrefix[0], nil
+	case len(byIDPrefix) > 1:
+		return nil, fmt.Errorf("--target %q is ambiguous: matches %d container IDs", target, len(byIDPrefix))
+	default:
+		return nil, fmt.Errorf("--target %q is not a valid IP/CIDR and does not match any running container name or ID", target)
+	}
+}

--- a/pkg/chaos/netem/target_test.go
+++ b/pkg/chaos/netem/target_test.go
@@ -1,0 +1,207 @@
+package netem
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func webContainer() *container.Container {
+	return &container.Container{
+		ContainerID:   "abc1234567890def",
+		ContainerName: "/web-1",
+		Networks: map[string]container.NetworkLink{
+			"bridge": {IPv4Address: "172.17.0.5"},
+		},
+	}
+}
+
+func TestResolveTargetNames_NoOpWhenEmpty(t *testing.T) {
+	// No ListContainers expectation is set up: if resolveTargetNames made a
+	// runtime call for the plain IP/CIDR case, this mock would panic on the
+	// unexpected call, failing the test.
+	mockClient := container.NewMockClient(t)
+	req := &container.NetemRequest{
+		IPs: []*net.IPNet{{IP: net.IPv4(10, 0, 0, 1), Mask: net.CIDRMask(32, 32)}},
+	}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.1/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ByName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"web-1"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+	assert.Empty(t, req.TargetNames, "TargetNames must be cleared once resolved")
+}
+
+func TestResolveTargetNames_MixedIPAndName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything,
+		mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{
+		IPs:         []*net.IPNet{{IP: net.IPv4(10, 0, 0, 1), Mask: net.CIDRMask(32, 32)}},
+		TargetNames: []string{"web-1"},
+	}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 2)
+	assert.Equal(t, "10.0.0.1/32", req.IPs[0].String())
+	assert.Equal(t, "172.17.0.5/32", req.IPs[1].String())
+}
+
+func TestResolveTargetNames_ByExactID(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc1234567890def"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ByUniqueIDPrefix(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc123"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
+}
+
+func TestResolveTargetNames_ShortIDPrefixNotMatched(t *testing.T) {
+	// Prefixes shorter than minIDPrefixLen are never tried against IDs, only
+	// exact names, to avoid a short typo accidentally landing on an
+	// unrelated container in a large fleet.
+	mockClient := container.NewMockClient(t)
+	c := webContainer()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abc"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"abc"`)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestResolveTargetNames_NotFound(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{webContainer()}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"does-not-exist"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"does-not-exist"`)
+	assert.Contains(t, err.Error(), "not a valid IP/CIDR")
+	assert.Contains(t, err.Error(), "does not match any running container")
+}
+
+func TestResolveTargetNames_AmbiguousName(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c1 := &container.Container{ContainerID: "id1", ContainerName: "dup", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.1"}}}
+	c2 := &container.Container{ContainerID: "id2", ContainerName: "dup", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.2"}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c1, c2}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"dup"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestResolveTargetNames_AmbiguousIDPrefix(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c1 := &container.Container{ContainerID: "abcdef123456", ContainerName: "c1", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.1"}}}
+	c2 := &container.Container{ContainerID: "abcdef789012", ContainerName: "c2", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.2"}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c1, c2}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"abcdef"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestResolveTargetNames_ContainerWithNoIP(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{ContainerID: "id1", ContainerName: "headless", Networks: map[string]container.NetworkLink{"host": {}}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"headless"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no IP address")
+}
+
+func TestResolveTargetNames_MultiNetworkContainer(t *testing.T) {
+	// A container attached to more than one network contributes every IP it
+	// has, not just one arbitrarily chosen network.
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{
+		ContainerID:   "id1",
+		ContainerName: "multi",
+		Networks: map[string]container.NetworkLink{
+			"front": {IPv4Address: "10.0.1.5"},
+			"back":  {IPv4Address: "10.0.2.5"},
+		},
+	}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"multi"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 2)
+	assert.Equal(t, "10.0.1.5/32", req.IPs[0].String())
+	assert.Equal(t, "10.0.2.5/32", req.IPs[1].String())
+}
+
+func TestResolveTargetNames_ListContainersError(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return(nil, errors.New("daemon unreachable"))
+
+	req := &container.NetemRequest{TargetNames: []string{"anything"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon unreachable")
+}
+
+func TestResolveTargetNames_EmptyTargetRejected(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{webContainer()}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{""}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+	require.Error(t, err)
+}

--- a/pkg/chaos/netem/target_test.go
+++ b/pkg/chaos/netem/target_test.go
@@ -22,6 +22,33 @@ func webContainer() *container.Container {
 	}
 }
 
+func TestResolveRequestTargetsDoesNotCacheResolvedAddresses(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	first := &container.Container{
+		ContainerID: "peer-id", ContainerName: "peer",
+		Networks: map[string]container.NetworkLink{"bridge": {IPv4Address: "10.0.0.1"}},
+	}
+	second := &container.Container{
+		ContainerID: "peer-id", ContainerName: "peer",
+		Networks: map[string]container.NetworkLink{"bridge": {IPv4Address: "10.0.0.2"}},
+	}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{first}, nil).Once()
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{second}, nil).Once()
+	original := &container.NetemRequest{TargetNames: []string{"peer"}}
+
+	firstRequest, err := resolveRequestTargets(context.Background(), mockClient, original)
+	require.NoError(t, err)
+	secondRequest, err := resolveRequestTargets(context.Background(), mockClient, original)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"peer"}, original.TargetNames)
+	assert.Empty(t, original.IPs)
+	assert.Equal(t, "10.0.0.1/32", firstRequest.IPs[0].String())
+	assert.Equal(t, "10.0.0.2/32", secondRequest.IPs[0].String())
+}
+
 func TestResolveTargetNames_NoOpWhenEmpty(t *testing.T) {
 	// No ListContainers expectation is set up: if resolveTargetNames made a
 	// runtime call for the plain IP/CIDR case, this mock would panic on the
@@ -49,6 +76,22 @@ func TestResolveTargetNames_ByName(t *testing.T) {
 	require.Len(t, req.IPs, 1)
 	assert.Equal(t, "172.17.0.5/32", req.IPs[0].String())
 	assert.Empty(t, req.TargetNames, "TargetNames must be cleared once resolved")
+}
+
+func TestResolveTargetNames_DeduplicatesRepeatedContainer(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{ContainerID: "peer-id", ContainerName: "peer", Networks: map[string]container.NetworkLink{}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+	mockClient.EXPECT().ContainerAddresses(mock.Anything, c).
+		Return([]net.IP{net.ParseIP("10.0.0.5")}, nil).Once()
+	req := &container.NetemRequest{TargetNames: []string{"peer", "peer"}}
+
+	err := resolveTargetNames(context.Background(), mockClient, req)
+
+	require.NoError(t, err)
+	require.Len(t, req.IPs, 1)
+	assert.Equal(t, "10.0.0.5/32", req.IPs[0].String())
 }
 
 func TestResolveTargetNames_MixedIPAndName(t *testing.T) {
@@ -137,6 +180,20 @@ func TestResolveTargetNames_AmbiguousName(t *testing.T) {
 	assert.Contains(t, err.Error(), "ambiguous")
 }
 
+func TestResolveTargetNames_AmbiguousAcrossExactNameAndID(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	byName := &container.Container{ContainerID: "id-1", ContainerName: "shared", Networks: map[string]container.NetworkLink{}}
+	byID := &container.Container{ContainerID: "shared", ContainerName: "other", Networks: map[string]container.NetworkLink{}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{byName, byID}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"shared"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
 func TestResolveTargetNames_AmbiguousIDPrefix(t *testing.T) {
 	mockClient := container.NewMockClient(t)
 	c1 := &container.Container{ContainerID: "abcdef123456", ContainerName: "c1", Networks: map[string]container.NetworkLink{"n": {IPv4Address: "10.1.1.1"}}}
@@ -150,11 +207,43 @@ func TestResolveTargetNames_AmbiguousIDPrefix(t *testing.T) {
 	assert.Contains(t, err.Error(), "ambiguous")
 }
 
+func TestResolveTargetNames_RejectsIPv6(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{ContainerID: "id1", ContainerName: "web-1", Networks: map[string]container.NetworkLink{}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+	mockClient.EXPECT().ContainerAddresses(mock.Anything, c).
+		Return([]net.IP{net.ParseIP("fd00::5")}, nil)
+
+	req := &container.NetemRequest{TargetNames: []string{"web-1"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv6")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestResolveTargetNames_AddressResolutionError(t *testing.T) {
+	mockClient := container.NewMockClient(t)
+	c := &container.Container{ContainerID: "id1", ContainerName: "web-1", Networks: map[string]container.NetworkLink{}}
+	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{c}, nil)
+	mockClient.EXPECT().ContainerAddresses(mock.Anything, c).
+		Return(nil, errors.New("network namespace unavailable"))
+
+	req := &container.NetemRequest{TargetNames: []string{"web-1"}}
+	err := resolveTargetNames(context.Background(), mockClient, req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network namespace unavailable")
+}
+
 func TestResolveTargetNames_ContainerWithNoIP(t *testing.T) {
 	mockClient := container.NewMockClient(t)
 	c := &container.Container{ContainerID: "id1", ContainerName: "headless", Networks: map[string]container.NetworkLink{"host": {}}}
 	mockClient.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
 		Return([]*container.Container{c}, nil)
+	mockClient.EXPECT().ContainerAddresses(mock.Anything, c).Return(nil, nil)
 
 	req := &container.NetemRequest{TargetNames: []string{"headless"}}
 	err := resolveTargetNames(context.Background(), mockClient, req)

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"net"
 	"time"
 )
 
@@ -14,6 +15,11 @@ type FilterFunc func(*Container) bool
 // Lister lists containers matching a filter.
 type Lister interface {
 	ListContainers(context.Context, FilterFunc, ListOpts) ([]*Container, error)
+}
+
+// AddressResolver returns the current network addresses of a container.
+type AddressResolver interface {
+	ContainerAddresses(context.Context, *Container) ([]net.IP, error)
 }
 
 // Lifecycle manages container lifecycle (stop, kill, start, restart, remove, pause).
@@ -58,6 +64,7 @@ type Stressor interface {
 // Client is the full container runtime interface, combining all focused interfaces.
 type Client interface {
 	Lister
+	AddressResolver
 	Lifecycle
 	Executor
 	Netem

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+	"net"
+	"sort"
 	"strings"
 )
 
@@ -17,9 +19,13 @@ const (
 	StateExited = "exited"
 )
 
-// NetworkLink represents a link from one container network endpoint.
+// NetworkLink represents a container's attachment to one network: the
+// legacy container links defined on that network, plus the IPv4 address
+// the runtime assigned the container on it (empty when the runtime doesn't
+// expose one, e.g. host networking or an unsupported runtime).
 type NetworkLink struct {
-	Links []string
+	Links       []string
+	IPv4Address string
 }
 
 // Container represents a running container, decoupled from any specific runtime.
@@ -68,6 +74,35 @@ func (c *Container) Links() []string {
 	}
 
 	return links
+}
+
+// IPs returns every distinct IPv4 address the container has across all of
+// its attached networks, sorted for a deterministic result. A container
+// connected to more than one Docker/Podman network (or with no network
+// address at all, e.g. host networking or a runtime that doesn't report
+// one) is expected and handled by callers explicitly rather than silently
+// picking a single "the" address.
+func (c *Container) IPs() []net.IP {
+	seen := make(map[string]struct{}, len(c.Networks))
+	var addrs []string
+	for _, n := range c.Networks {
+		if n.IPv4Address == "" {
+			continue
+		}
+		if _, ok := seen[n.IPv4Address]; ok {
+			continue
+		}
+		seen[n.IPv4Address] = struct{}{}
+		addrs = append(addrs, n.IPv4Address)
+	}
+	sort.Strings(addrs)
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+	return ips
 }
 
 // IsPumba returns a boolean flag indicating whether or not the current

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -20,12 +20,13 @@ const (
 )
 
 // NetworkLink represents a container's attachment to one network: the
-// legacy container links defined on that network, plus the IPv4 address
-// the runtime assigned the container on it (empty when the runtime doesn't
-// expose one, e.g. host networking or an unsupported runtime).
+// legacy container links defined on that network, plus the IP addresses
+// the runtime assigned the container on it. Addresses are empty when the
+// runtime doesn't expose them, such as host networking.
 type NetworkLink struct {
 	Links       []string
 	IPv4Address string
+	IPv6Address string
 }
 
 // Container represents a running container, decoupled from any specific runtime.
@@ -76,31 +77,36 @@ func (c *Container) Links() []string {
 	return links
 }
 
-// IPs returns every distinct IPv4 address the container has across all of
+// IPs returns every distinct IP address the container has across all of
 // its attached networks, sorted for a deterministic result. A container
-// connected to more than one Docker/Podman network (or with no network
-// address at all, e.g. host networking or a runtime that doesn't report
-// one) is expected and handled by callers explicitly rather than silently
-// picking a single "the" address.
+// connected to more than one network, or with no reported address, is
+// handled by callers explicitly rather than by picking one address.
 func (c *Container) IPs() []net.IP {
 	seen := make(map[string]struct{}, len(c.Networks))
 	var addrs []string
 	for _, n := range c.Networks {
-		if n.IPv4Address == "" {
-			continue
+		for _, address := range []string{n.IPv4Address, n.IPv6Address} {
+			if address == "" {
+				continue
+			}
+			if _, ok := seen[address]; ok {
+				continue
+			}
+			seen[address] = struct{}{}
+			addrs = append(addrs, address)
 		}
-		if _, ok := seen[n.IPv4Address]; ok {
-			continue
-		}
-		seen[n.IPv4Address] = struct{}{}
-		addrs = append(addrs, n.IPv4Address)
 	}
 	sort.Strings(addrs)
 	ips := make([]net.IP, 0, len(addrs))
-	for _, a := range addrs {
-		if ip := net.ParseIP(a); ip != nil {
-			ips = append(ips, ip)
+	for _, address := range addrs {
+		ip := net.ParseIP(address)
+		if ip == nil {
+			continue
 		}
+		if ipv4 := ip.To4(); ipv4 != nil {
+			ip = ipv4
+		}
+		ips = append(ips, ip)
 	}
 	return ips
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -183,15 +183,16 @@ func TestIPs_MultipleNetworks_SortedAndDeduped(t *testing.T) {
 	c := Container{
 		Labels: map[string]string{},
 		Networks: map[string]NetworkLink{
-			"backend":  {IPv4Address: "10.0.2.5"},
+			"backend":  {IPv4Address: "10.0.2.5", IPv6Address: "fd00::5"},
 			"frontend": {IPv4Address: "10.0.1.5"},
-			"dup":      {IPv4Address: "10.0.1.5"}, // same address on another network: deduped
+			"dup":      {IPv4Address: "10.0.1.5", IPv6Address: "fd00::5"},
 		},
 	}
 	ips := c.IPs()
-	require.Len(t, ips, 2)
+	require.Len(t, ips, 3)
 	assert.Equal(t, "10.0.1.5", ips[0].String())
 	assert.Equal(t, "10.0.2.5", ips[1].String())
+	assert.Equal(t, "fd00::5", ips[2].String())
 }
 
 func TestIPs_NoAddress(t *testing.T) {

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestID(t *testing.T) {
@@ -164,6 +165,51 @@ func TestLinks_NetworkWithNoLinks(t *testing.T) {
 		},
 	}
 	assert.Nil(t, c.Links())
+}
+
+func TestIPs_SingleNetwork(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"bridge": {IPv4Address: "172.17.0.5"},
+		},
+	}
+	ips := c.IPs()
+	require.Len(t, ips, 1)
+	assert.Equal(t, "172.17.0.5", ips[0].String())
+}
+
+func TestIPs_MultipleNetworks_SortedAndDeduped(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"backend":  {IPv4Address: "10.0.2.5"},
+			"frontend": {IPv4Address: "10.0.1.5"},
+			"dup":      {IPv4Address: "10.0.1.5"}, // same address on another network: deduped
+		},
+	}
+	ips := c.IPs()
+	require.Len(t, ips, 2)
+	assert.Equal(t, "10.0.1.5", ips[0].String())
+	assert.Equal(t, "10.0.2.5", ips[1].String())
+}
+
+func TestIPs_NoAddress(t *testing.T) {
+	c := Container{
+		Labels: map[string]string{},
+		Networks: map[string]NetworkLink{
+			"host": {},
+		},
+	}
+	assert.Empty(t, c.IPs())
+}
+
+func TestIPs_EmptyNetworks(t *testing.T) {
+	c := Container{
+		Labels:   map[string]string{},
+		Networks: map[string]NetworkLink{},
+	}
+	assert.Empty(t, c.IPs())
 }
 
 func TestIsPumbaSkip_WrongValue(t *testing.T) {

--- a/pkg/container/mock_Client.go
+++ b/pkg/container/mock_Client.go
@@ -6,6 +6,7 @@ package container
 
 import (
 	"context"
+	"net"
 	"time"
 
 	mock "github.com/stretchr/testify/mock"
@@ -78,6 +79,74 @@ func (_c *MockClient_Close_Call) Return(err error) *MockClient_Close_Call {
 }
 
 func (_c *MockClient_Close_Call) RunAndReturn(run func() error) *MockClient_Close_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ContainerAddresses provides a mock function for the type MockClient
+func (_mock *MockClient) ContainerAddresses(context1 context.Context, container *Container) ([]net.IP, error) {
+	ret := _mock.Called(context1, container)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ContainerAddresses")
+	}
+
+	var r0 []net.IP
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Container) ([]net.IP, error)); ok {
+		return returnFunc(context1, container)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Container) []net.IP); ok {
+		r0 = returnFunc(context1, container)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]net.IP)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *Container) error); ok {
+		r1 = returnFunc(context1, container)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ContainerAddresses_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ContainerAddresses'
+type MockClient_ContainerAddresses_Call struct {
+	*mock.Call
+}
+
+// ContainerAddresses is a helper method to define mock.On call
+//   - context1 context.Context
+//   - container *Container
+func (_e *MockClient_Expecter) ContainerAddresses(context1 any, container any) *MockClient_ContainerAddresses_Call {
+	return &MockClient_ContainerAddresses_Call{Call: _e.mock.On("ContainerAddresses", context1, container)}
+}
+
+func (_c *MockClient_ContainerAddresses_Call) Run(run func(context1 context.Context, container *Container)) *MockClient_ContainerAddresses_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *Container
+		if args[1] != nil {
+			arg1 = args[1].(*Container)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ContainerAddresses_Call) Return(iPs []net.IP, err error) *MockClient_ContainerAddresses_Call {
+	_c.Call.Return(iPs, err)
+	return _c
+}
+
+func (_c *MockClient_ContainerAddresses_Call) RunAndReturn(run func(context1 context.Context, container *Container) ([]net.IP, error)) *MockClient_ContainerAddresses_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/container/requests.go
+++ b/pkg/container/requests.go
@@ -22,11 +22,20 @@ type NetemRequest struct {
 	Interface string
 	Command   []string
 	IPs       []*net.IPNet
-	SPorts    []string
-	DPorts    []string
-	Duration  time.Duration
-	Sidecar   SidecarSpec
-	DryRun    bool
+	// TargetNames holds --target values that were not valid IP/CIDR
+	// literals at parse time (no runtime client is available yet then).
+	// They are candidate container names or IDs, resolved to IPs — and
+	// folded into IPs — the first time a command runs, once a runtime
+	// client is available. Empty for the common IP/CIDR-only case, so
+	// existing callers see no behavior change. Runtime adapters
+	// (pkg/runtime/*) never need to look at this field: by the time a
+	// request reaches them it has already been resolved.
+	TargetNames []string
+	SPorts      []string
+	DPorts      []string
+	Duration    time.Duration
+	Sidecar     SidecarSpec
+	DryRun      bool
 }
 
 // IPTablesRequest carries every parameter required to apply or stop an

--- a/pkg/container/requests.go
+++ b/pkg/container/requests.go
@@ -24,10 +24,10 @@ type NetemRequest struct {
 	IPs       []*net.IPNet
 	// TargetNames holds --target values that were not valid IP/CIDR
 	// literals at parse time (no runtime client is available yet then).
-	// They are candidate container names or IDs, resolved to IPs — and
-	// folded into IPs — the first time a command runs, once a runtime
-	// client is available. Empty for the common IP/CIDR-only case, so
-	// existing callers see no behavior change. Runtime adapters
+	// They are candidate container names or IDs. Each command invocation
+	// resolves them into IPs on a request copy, so interval runs do not cache
+	// addresses across container restarts. Empty for the common IP/CIDR-only
+	// case, so existing callers see no behavior change. Runtime adapters
 	// (pkg/runtime/*) never need to look at this field: by the time a
 	// request reaches them it has already been resolved.
 	TargetNames []string

--- a/pkg/runtime/containerd/addresses.go
+++ b/pkg/runtime/containerd/addresses.go
@@ -1,0 +1,145 @@
+package containerd
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"sort"
+	"strings"
+
+	ctr "github.com/alexei-led/pumba/pkg/container"
+)
+
+// ContainerAddresses reads addresses from the target task's network namespace.
+func (c *containerdClient) ContainerAddresses(ctx context.Context, container *ctr.Container) ([]net.IP, error) {
+	ctx = c.nsCtx(ctx)
+	cntr, err := c.client.LoadContainer(ctx, container.ID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to load container %s: %w", container.ID(), err)
+	}
+	task, err := cntr.Task(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get task for %s: %w", container.ID(), err)
+	}
+	pid := task.Pid()
+	if pid == 0 {
+		return nil, fmt.Errorf("container %s task has no PID", container.ID())
+	}
+
+	sameNamespace := c.sameNetworkNamespace
+	if sameNamespace == nil {
+		sameNamespace = isHostNetworkNamespace
+	}
+	hostNetwork, err := sameNamespace(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect network namespace for container %s: %w", container.ID(), err)
+	}
+	if hostNetwork {
+		return nil, nil
+	}
+
+	readFile := c.readProcessFile
+	if readFile == nil {
+		readFile = os.ReadFile
+	}
+	fibTrie, err := readFile(fmt.Sprintf("/proc/%d/net/fib_trie", pid))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read IPv4 addresses for container %s: %w", container.ID(), err)
+	}
+	ipv6, err := readFile(fmt.Sprintf("/proc/%d/net/if_inet6", pid))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("failed to read IPv6 addresses for container %s: %w", container.ID(), err)
+	}
+	return parseProcessAddresses(fibTrie, ipv6)
+}
+
+func isHostNetworkNamespace(pid uint32) (bool, error) {
+	self, err := os.Stat("/proc/self/ns/net")
+	if err != nil {
+		return false, err
+	}
+	target, err := os.Stat(fmt.Sprintf("/proc/%d/ns/net", pid))
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(self, target), nil
+}
+
+func parseProcessAddresses(fibTrie, ifInet6 []byte) ([]net.IP, error) {
+	ipv4, err := parseIPv4Addresses(fibTrie)
+	if err != nil {
+		return nil, err
+	}
+	ipv6, err := parseIPv6Addresses(ifInet6)
+	if err != nil {
+		return nil, err
+	}
+	addresses := make(map[string]net.IP, len(ipv4)+len(ipv6))
+	for _, ip := range append(ipv4, ipv6...) {
+		addresses[ip.String()] = ip
+	}
+	keys := make([]string, 0, len(addresses))
+	for address := range addresses {
+		keys = append(keys, address)
+	}
+	sort.Strings(keys)
+	result := make([]net.IP, 0, len(keys))
+	for _, address := range keys {
+		result = append(result, addresses[address])
+	}
+	return result, nil
+}
+
+func parseIPv4Addresses(fibTrie []byte) ([]net.IP, error) {
+	var addresses []net.IP
+	var candidate net.IP
+	scanner := bufio.NewScanner(strings.NewReader(string(fibTrie)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) == 2 && (fields[0] == "|--" || fields[0] == "+--") {
+			candidate = net.ParseIP(fields[1]).To4()
+			continue
+		}
+		if strings.Contains(line, "/32 host LOCAL") && isTargetAddress(candidate) {
+			addresses = append(addresses, candidate)
+		}
+		candidate = nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to parse IPv4 addresses: %w", err)
+	}
+	return addresses, nil
+}
+
+func parseIPv6Addresses(ifInet6 []byte) ([]net.IP, error) {
+	var addresses []net.IP
+	scanner := bufio.NewScanner(strings.NewReader(string(ifInet6)))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		value, err := hex.DecodeString(fields[0])
+		if err != nil || len(value) != net.IPv6len {
+			return nil, fmt.Errorf("invalid IPv6 address %q", fields[0])
+		}
+		ip := net.IP(value)
+		if isTargetAddress(ip) {
+			addresses = append(addresses, ip)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to parse IPv6 addresses: %w", err)
+	}
+	return addresses, nil
+}
+
+func isTargetAddress(ip net.IP) bool {
+	return ip != nil && ip.IsGlobalUnicast() && !ip.IsLinkLocalUnicast()
+}

--- a/pkg/runtime/containerd/addresses_test.go
+++ b/pkg/runtime/containerd/addresses_test.go
@@ -1,0 +1,85 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	ctr "github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testFibTrie = `Main:
+  +-- 0.0.0.0/0 3 0 5
+     +-- 10.42.0.0/24 2 0 2
+        |-- 10.42.0.7
+           /32 host LOCAL
+     +-- 127.0.0.0/8 2 0 2
+        |-- 127.0.0.1
+           /32 host LOCAL
+Local:
+  +-- 10.42.0.7
+     |-- 10.42.0.7
+        /32 host LOCAL
+`
+
+const testIPv6Addresses = `00000000000000000000000000000001 01 80 10 80 lo
+fd000000000000000000000000000007 02 40 00 80 eth0
+fe800000000000000000000000000001 02 40 20 80 eth0
+`
+
+func TestParseProcessAddresses(t *testing.T) {
+	addresses, err := parseProcessAddresses([]byte(testFibTrie), []byte(testIPv6Addresses))
+
+	require.NoError(t, err)
+	assert.Equal(t, []net.IP{
+		net.ParseIP("10.42.0.7").To4(),
+		net.ParseIP("fd00::7"),
+	}, addresses)
+}
+
+func TestContainerAddresses(t *testing.T) {
+	api := NewMockapiClient(t)
+	cntr := NewMockContainer(t)
+	task := NewMockTask(t)
+	api.EXPECT().LoadContainer(mock.Anything, "target-id").Return(cntr, nil)
+	cntr.EXPECT().Task(mock.Anything, mock.Anything).Return(task, nil)
+	task.EXPECT().Pid().Return(uint32(1234))
+	client := newTestClient(api)
+	client.sameNetworkNamespace = func(uint32) (bool, error) { return false, nil }
+	client.readProcessFile = func(path string) ([]byte, error) {
+		switch {
+		case strings.HasSuffix(path, "/net/fib_trie"):
+			return []byte(testFibTrie), nil
+		case strings.HasSuffix(path, "/net/if_inet6"):
+			return []byte(testIPv6Addresses), nil
+		default:
+			return nil, errors.New("unexpected path")
+		}
+	}
+
+	addresses, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []net.IP{net.ParseIP("10.42.0.7").To4(), net.ParseIP("fd00::7")}, addresses)
+}
+
+func TestContainerAddressesHostNetworkReturnsNoAddress(t *testing.T) {
+	api := NewMockapiClient(t)
+	cntr := NewMockContainer(t)
+	task := NewMockTask(t)
+	api.EXPECT().LoadContainer(mock.Anything, "target-id").Return(cntr, nil)
+	cntr.EXPECT().Task(mock.Anything, mock.Anything).Return(task, nil)
+	task.EXPECT().Pid().Return(uint32(1234))
+	client := newTestClient(api)
+	client.sameNetworkNamespace = func(uint32) (bool, error) { return true, nil }
+
+	addresses, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+	require.NoError(t, err)
+	assert.Empty(t, addresses)
+}

--- a/pkg/runtime/containerd/addresses_test.go
+++ b/pkg/runtime/containerd/addresses_test.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"net"
 	"strings"
 	"testing"
@@ -68,6 +69,94 @@ func TestContainerAddresses(t *testing.T) {
 	assert.Equal(t, []net.IP{net.ParseIP("10.42.0.7").To4(), net.ParseIP("fd00::7")}, addresses)
 }
 
+func TestContainerAddressesErrors(t *testing.T) {
+	t.Run("load container", func(t *testing.T) {
+		api := NewMockapiClient(t)
+		api.EXPECT().LoadContainer(mock.Anything, "target-id").Return(nil, errors.New("load failed"))
+		client := newTestClient(api)
+
+		_, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+		require.ErrorContains(t, err, "load failed")
+	})
+
+	t.Run("get task", func(t *testing.T) {
+		api := NewMockapiClient(t)
+		cntr := NewMockContainer(t)
+		api.EXPECT().LoadContainer(mock.Anything, "target-id").Return(cntr, nil)
+		cntr.EXPECT().Task(mock.Anything, mock.Anything).Return(nil, errors.New("task failed"))
+		client := newTestClient(api)
+
+		_, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+		require.ErrorContains(t, err, "task failed")
+	})
+
+	t.Run("missing task PID", func(t *testing.T) {
+		client := addressTestClient(t, 0)
+
+		_, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+		require.ErrorContains(t, err, "has no PID")
+	})
+
+	t.Run("inspect namespace", func(t *testing.T) {
+		client := addressTestClient(t, 1234)
+		client.sameNetworkNamespace = func(uint32) (bool, error) {
+			return false, errors.New("namespace failed")
+		}
+
+		_, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+		require.ErrorContains(t, err, "namespace failed")
+	})
+
+	for _, tc := range []struct {
+		name       string
+		failedFile string
+	}{
+		{name: "read IPv4", failedFile: "/net/fib_trie"},
+		{name: "read IPv6", failedFile: "/net/if_inet6"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := addressTestClient(t, 1234)
+			client.sameNetworkNamespace = func(uint32) (bool, error) { return false, nil }
+			client.readProcessFile = func(path string) ([]byte, error) {
+				if strings.HasSuffix(path, tc.failedFile) {
+					return nil, errors.New("read failed")
+				}
+				return []byte(testFibTrie), nil
+			}
+
+			_, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+			require.ErrorContains(t, err, "read failed")
+		})
+	}
+}
+
+func TestContainerAddressesAllowsMissingIPv6ProcFile(t *testing.T) {
+	client := addressTestClient(t, 1234)
+	client.sameNetworkNamespace = func(uint32) (bool, error) { return false, nil }
+	client.readProcessFile = func(path string) ([]byte, error) {
+		if strings.HasSuffix(path, "/net/if_inet6") {
+			return nil, fs.ErrNotExist
+		}
+		return []byte(testFibTrie), nil
+	}
+
+	addresses, err := client.ContainerAddresses(context.Background(), &ctr.Container{ContainerID: "target-id"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []net.IP{net.ParseIP("10.42.0.7").To4()}, addresses)
+}
+
+func TestParseProcessAddressesRejectsInvalidIPv6(t *testing.T) {
+	_, err := parseProcessAddresses(nil, []byte("not-hex 01 80 10 80 eth0"))
+
+	require.ErrorContains(t, err, "invalid IPv6 address")
+}
+
 func TestContainerAddressesHostNetworkReturnsNoAddress(t *testing.T) {
 	api := NewMockapiClient(t)
 	cntr := NewMockContainer(t)
@@ -82,4 +171,15 @@ func TestContainerAddressesHostNetworkReturnsNoAddress(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, addresses)
+}
+
+func addressTestClient(t *testing.T, pid uint32) *containerdClient {
+	t.Helper()
+	api := NewMockapiClient(t)
+	cntr := NewMockContainer(t)
+	task := NewMockTask(t)
+	api.EXPECT().LoadContainer(mock.Anything, "target-id").Return(cntr, nil)
+	cntr.EXPECT().Task(mock.Anything, mock.Anything).Return(task, nil)
+	task.EXPECT().Pid().Return(pid)
+	return newTestClient(api)
 }

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -23,8 +23,10 @@ const (
 
 // containerdClient implements ctr.Client for the containerd runtime.
 type containerdClient struct {
-	client    apiClient
-	namespace string
+	client               apiClient
+	namespace            string
+	readProcessFile      func(string) ([]byte, error)
+	sameNetworkNamespace func(uint32) (bool, error)
 }
 
 // NewClient creates a new containerd client connected to the given socket.

--- a/pkg/runtime/docker/addresses.go
+++ b/pkg/runtime/docker/addresses.go
@@ -1,0 +1,14 @@
+package docker
+
+import (
+	"context"
+	"net"
+
+	ctr "github.com/alexei-led/pumba/pkg/container"
+)
+
+// ContainerAddresses returns addresses already captured by the runtime inspect
+// performed while listing containers.
+func (c dockerClient) ContainerAddresses(_ context.Context, container *ctr.Container) ([]net.IP, error) {
+	return container.IPs(), nil
+}

--- a/pkg/runtime/docker/addresses_test.go
+++ b/pkg/runtime/docker/addresses_test.go
@@ -1,0 +1,30 @@
+package docker
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	ctr "github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerAddressesUsesInspectedNetworks(t *testing.T) {
+	client := &dockerClient{}
+	container := &ctr.Container{
+		Networks: map[string]ctr.NetworkLink{
+			"front": {IPv4Address: "10.0.1.5", IPv6Address: "fd00::5"},
+			"back":  {IPv4Address: "10.0.2.5"},
+		},
+	}
+
+	addresses, err := client.ContainerAddresses(context.Background(), container)
+
+	require.NoError(t, err)
+	assert.Equal(t, []net.IP{
+		net.ParseIP("10.0.1.5").To4(),
+		net.ParseIP("10.0.2.5").To4(),
+		net.ParseIP("fd00::5"),
+	}, addresses)
+}

--- a/pkg/runtime/docker/inspect.go
+++ b/pkg/runtime/docker/inspect.go
@@ -35,7 +35,7 @@ func dockerInspectToContainer(info ctypes.InspectResponse, img *imagetypes.Inspe
 	}
 	if info.NetworkSettings != nil {
 		for name, ep := range info.NetworkSettings.Networks {
-			c.Networks[name] = ctr.NetworkLink{Links: ep.Links}
+			c.Networks[name] = ctr.NetworkLink{Links: ep.Links, IPv4Address: ep.IPAddress}
 		}
 	}
 	return c

--- a/pkg/runtime/docker/inspect.go
+++ b/pkg/runtime/docker/inspect.go
@@ -35,7 +35,11 @@ func dockerInspectToContainer(info ctypes.InspectResponse, img *imagetypes.Inspe
 	}
 	if info.NetworkSettings != nil {
 		for name, ep := range info.NetworkSettings.Networks {
-			c.Networks[name] = ctr.NetworkLink{Links: ep.Links, IPv4Address: ep.IPAddress}
+			c.Networks[name] = ctr.NetworkLink{
+				Links:       ep.Links,
+				IPv4Address: ep.IPAddress,
+				IPv6Address: ep.GlobalIPv6Address,
+			}
 		}
 	}
 	return c

--- a/pkg/runtime/docker/inspect_test.go
+++ b/pkg/runtime/docker/inspect_test.go
@@ -148,6 +148,39 @@ func TestDockerInspectToContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "container with IP addresses on multiple networks",
+			info: ctypes.InspectResponse{
+				ContainerJSONBase: &ctypes.ContainerJSONBase{
+					ID:    "abc123",
+					Name:  "/multi-net",
+					Image: "nginx:1.25",
+					State: &ctypes.State{Running: true},
+				},
+				Config: &ctypes.Config{Labels: map[string]string{}},
+				NetworkSettings: &ctypes.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						"frontend": {Links: []string{"db:db"}, IPAddress: "172.18.0.2"},
+						"backend":  {IPAddress: "172.19.0.3"},
+						"host":     {IPAddress: ""},
+					},
+				},
+			},
+			img: &imagetypes.InspectResponse{ID: "sha256:img123"},
+			expected: &ctr.Container{
+				ContainerID:   "abc123",
+				ContainerName: "/multi-net",
+				Image:         "nginx:1.25",
+				ImageID:       "sha256:img123",
+				State:         ctr.StateRunning,
+				Labels:        map[string]string{},
+				Networks: map[string]ctr.NetworkLink{
+					"frontend": {Links: []string{"db:db"}, IPv4Address: "172.18.0.2"},
+					"backend":  {IPv4Address: "172.19.0.3"},
+					"host":     {IPv4Address: ""},
+				},
+			},
+		},
+		{
 			name: "exited container",
 			info: ctypes.InspectResponse{
 				ContainerJSONBase: &ctypes.ContainerJSONBase{

--- a/pkg/runtime/docker/inspect_test.go
+++ b/pkg/runtime/docker/inspect_test.go
@@ -160,7 +160,7 @@ func TestDockerInspectToContainer(t *testing.T) {
 				NetworkSettings: &ctypes.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
 						"frontend": {Links: []string{"db:db"}, IPAddress: "172.18.0.2"},
-						"backend":  {IPAddress: "172.19.0.3"},
+						"backend":  {IPAddress: "172.19.0.3", GlobalIPv6Address: "fd00::3"},
 						"host":     {IPAddress: ""},
 					},
 				},
@@ -175,7 +175,7 @@ func TestDockerInspectToContainer(t *testing.T) {
 				Labels:        map[string]string{},
 				Networks: map[string]ctr.NetworkLink{
 					"frontend": {Links: []string{"db:db"}, IPv4Address: "172.18.0.2"},
-					"backend":  {IPv4Address: "172.19.0.3"},
+					"backend":  {IPv4Address: "172.19.0.3", IPv6Address: "fd00::3"},
 					"host":     {IPv4Address: ""},
 				},
 			},

--- a/pkg/runtime/docker/mockengine_responses.go
+++ b/pkg/runtime/docker/mockengine_responses.go
@@ -33,6 +33,7 @@ func DetailsResponse(params map[string]any) ctypes.InspectResponse {
 	Labels := lookupWithDefault(params, "Labels", map[string]string{}).(map[string]string)
 	Links := lookupWithDefault(params, "Links", []string{}).([]string)
 	CgroupParent := lookupWithDefault(params, "CgroupParent", "").(string)
+	IPAddress := lookupWithDefault(params, "IPAddress", "").(string)
 
 	resp := ctypes.InspectResponse{
 		ContainerJSONBase: &ctypes.ContainerJSONBase{
@@ -52,7 +53,7 @@ func DetailsResponse(params map[string]any) ctypes.InspectResponse {
 		},
 		NetworkSettings: &ctypes.NetworkSettings{
 			Networks: map[string]*networktypes.EndpointSettings{
-				"default": {Links: Links},
+				"default": {Links: Links, IPAddress: IPAddress},
 			},
 		},
 	}

--- a/tests/containerd_netem.bats
+++ b/tests/containerd_netem.bats
@@ -7,6 +7,8 @@ setup() {
     # Clean up any leftovers
     sudo ctr -n moby t kill -s SIGKILL test-netem-ctr >/dev/null 2>&1 || true
     sudo ctr -n moby c rm test-netem-ctr >/dev/null 2>&1 || true
+    sudo ctr -n moby t kill -s SIGKILL test-netem-peer >/dev/null 2>&1 || true
+    sudo ctr -n moby c rm test-netem-peer >/dev/null 2>&1 || true
     # Pull images: netshoot for the target container, nettools for pumba's sidecar
     ctr_pull_image moby docker.io/nicolaka/netshoot:latest
     ctr_pull_image moby ghcr.io/alexei-led/pumba-alpine-nettools:latest
@@ -22,6 +24,8 @@ teardown() {
     kill %1 2>/dev/null || true
     sudo ctr -n moby t kill -s SIGKILL test-netem-ctr >/dev/null 2>&1 || true
     sudo ctr -n moby c rm test-netem-ctr >/dev/null 2>&1 || true
+    sudo ctr -n moby t kill -s SIGKILL test-netem-peer >/dev/null 2>&1 || true
+    sudo ctr -n moby c rm test-netem-peer >/dev/null 2>&1 || true
     # Clean up any leftover sidecar containers
     for sc in $(sudo ctr -n moby c ls -q 2>/dev/null | grep pumba-sidecar); do
         sudo ctr -n moby t kill -s SIGKILL $sc >/dev/null 2>&1 || true
@@ -70,6 +74,18 @@ teardown() {
     run sudo ctr -n moby t exec --exec-id scoped-root-after test-netem-ctr tc qdisc show dev dummy0
     assert_success
     [ "$output" = "$root_before" ]
+    refute_output --partial "504d:"
+}
+
+@test "Should resolve a target container name via containerd runtime" {
+    sudo ctr -n moby run -d --privileged docker.io/nicolaka/netshoot:latest test-netem-peer \
+        sh -c "ip link add dummy0 type dummy && ip addr add 10.77.0.2/32 dev dummy0 && ip link set dummy0 up && sleep infinity" >/dev/null 2>&1
+    wait_for_ctr_running moby test-netem-peer
+
+    run sudo pumba --runtime containerd --containerd-namespace moby --log-level debug netem --interface dummy0 --pull-image=false --target test-netem-peer --duration 2s delay --time 100 test-netem-ctr
+    assert_success
+
+    run sudo ctr -n moby t exec --exec-id check-target-clean test-netem-ctr tc qdisc show dev dummy0
     refute_output --partial "504d:"
 }
 

--- a/tests/netem.bats
+++ b/tests/netem.bats
@@ -8,6 +8,7 @@ setup() {
     # Clean any leftover containers from previous test runs
     cleanup_containers "pingtest"
     cleanup_containers "netem_target"
+    cleanup_containers "netem_peer"
     cleanup_containers "rate_limit_target"
 
     # Also cleanup any nettools containers that might be left running
@@ -21,6 +22,7 @@ teardown() {
     # Clean up containers after each test
     cleanup_containers "pingtest"
     cleanup_containers "netem_target"
+    cleanup_containers "netem_peer"
     cleanup_containers "rate_limit_target"
     
     # Also cleanup any nettools containers that might be left running
@@ -97,6 +99,22 @@ teardown() {
     # Verify cleanup
     assert_netem_cleaned "pingtest"
     assert_sidecar_cleaned
+}
+
+@test "Should resolve a target container name for netem filtering" {
+    create_test_container "pingtest" "alpine" "sleep infinity"
+    create_test_container "netem_peer" "alpine" "sleep infinity"
+    ensure_nettools_image
+
+    pumba netem --duration 5s --tc-image "${NETTOOLS_IMAGE}" --pull-image=false --target netem_peer delay --time 100 pingtest &
+    PUMBA_PID=$!
+
+    wait_for 5 "nsenter -t \$(docker inspect -f '{{.State.Pid}}' pingtest) -n tc filter show dev eth0 parent 504d: 2>/dev/null | grep -q 'flowid 504d:3'" "resolved target filter to be applied"
+
+    wait "$PUMBA_PID"
+    local pumba_exit=$?
+    [ "$pumba_exit" -eq 0 ]
+    assert_netem_cleaned "pingtest"
 }
 
 @test "Should validate packet loss command syntax" {

--- a/tests/podman_netem.bats
+++ b/tests/podman_netem.bats
@@ -25,6 +25,7 @@ setup() {
         skip "podman is rootless — netem requires rootful mode"
     fi
     podman_rm_force pdm-netem-ctr
+    podman_rm_force pdm-netem-peer
     podman pull docker.io/nicolaka/netshoot:latest >/dev/null 2>&1 || true
     podman pull ghcr.io/alexei-led/pumba-alpine-nettools:latest >/dev/null 2>&1 || true
     podman run -d --privileged --name pdm-netem-ctr docker.io/nicolaka/netshoot:latest \
@@ -36,6 +37,7 @@ teardown() {
     sudo pkill -f "pumba.*netem.*pdm-netem-ctr" 2>/dev/null || true
     kill %1 2>/dev/null || true
     podman_rm_force pdm-netem-ctr
+    podman_rm_force pdm-netem-peer
     # Reap any lingering sidecar containers (identified by pumba skip label)
     for sc in $(podman ps -q --filter "label=com.gaiaadm.pumba.skip=true" 2>/dev/null); do
         podman rm -f "$sc" >/dev/null 2>&1 || true
@@ -62,6 +64,17 @@ teardown() {
     run podman exec pdm-netem-ctr tc qdisc show dev dummy0
     echo "TC after cleanup: $output"
     refute_output --partial "netem"
+}
+
+@test "Should resolve a target container name via podman runtime" {
+    podman run -d --name pdm-netem-peer docker.io/nicolaka/netshoot:latest sleep infinity >/dev/null 2>&1
+    wait_for_running podman pdm-netem-peer
+
+    run pumba --runtime podman --log-level debug netem --interface dummy0 --pull-image=false --target pdm-netem-peer --duration 2s delay --time 100 pdm-netem-ctr
+    assert_success
+
+    run podman exec pdm-netem-ctr tc qdisc show dev dummy0
+    refute_output --partial "504d:"
 }
 
 @test "Should apply packet loss via podman runtime" {


### PR DESCRIPTION
Closes #90.

## Summary
- accept running container names, full IDs, and unique ID prefixes in repeatable `--target` flags
- resolve every IPv4 address at each command/interval run without leaking names to runtime adapters
- add Docker/Podman inspect resolution and containerd network-namespace address discovery
- reject ambiguous selectors and IPv6 targets explicitly
- deduplicate equivalent literal and resolved targets
- cover Docker, Podman, and containerd integration paths and update CLI/docs

## Validation
- `CGO_ENABLED=0 go test ./...`
- `golangci-lint run -c .golangci.yaml --new-from-rev=origin/master ./...`
- `make mocks` reproducibility checksum
- independent review: PASS (no Critical/High/Medium findings)

Local Bats execution was unavailable because Colima/Docker is not running and the host Bats install lacks bats-support. GitHub integration jobs exercise the added cases.
