### PR TITLE
feat(netem): combine effects in one qdisc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ pkg/
     cliflags/          — urfave/cli v1 adapter (Flags interface + V1, NewV1FromApp for app-level context) decoupling cmd builders from cli.Context
     lifecycle/         — Runtime-agnostic lifecycle chaos actions (kill, stop, pause, rm, exec, restart)
     lifecycle/cmd/     — CLI command builders for lifecycle chaos actions
-    netem/             — Network emulation (delay, loss, corrupt, duplicate, rate, loss_ge, loss_state)
+    netem/             — Network emulation (combine, delay, loss, corrupt, duplicate, rate, loss_ge, loss_state)
     netem/cmd/         — CLI command builders for netem
     iptables/          — iptables-based packet filtering
     iptables/cmd/      — CLI command builders for iptables
@@ -87,7 +87,7 @@ examples/              — Demo scripts
 - **Runtime factory injection** (`pkg/chaos/command.go`): `chaos.Runtime func() container.Client` is a closure-based factory. Every CLI builder constructor takes `runtime chaos.Runtime` explicitly — no `chaos.DockerClient` global, no service locator. `cmd/main.go::before` constructs the closure once after global flag parsing and propagates it through `initializeCLICommands`.
 - **Canonical chaos fanout** (`pkg/chaos/runner.go`): `RunOnContainers(ctx, lister, gp, limit, random, parallel, fn)` is the single helper every chaos action's `Run()` calls — it lists matching containers, optionally narrows to a random pick, and runs `fn` either via `errgroup` (parallel) or sequentially (serial). `RunOnContainersAll` variant lists stopped + running for lifecycle ops that target stopped containers. New chaos actions MUST use this helper instead of hand-rolling the list-then-fanout loop.
 - **Interface name validation** (`pkg/util/util.go::ValidateInterfaceName`): single source of truth for the `eth0`/`en0`/`lo`/`vlan.10` regex check; both `pkg/chaos/netem/parse.go` and `pkg/chaos/iptables/parse.go` call it. Never re-introduce a local `regexp.MustCompile` for interface names.
-- **Generic CLI builder** (`pkg/chaos/cmd/builder.go`): `NewAction[P]` collapses all 17 chaos cmd files into the same shape — flag list + typed `ParamParser[P]` + `CommandFactory[P]`. Parsers receive `cliflags.Flags`, never `*cli.Context` directly.
+- **Generic CLI builder** (`pkg/chaos/cmd/builder.go`): `NewAction[P]` keeps chaos action cmd files in the same shape — flag list + typed `ParamParser[P]` + `CommandFactory[P]`. Parsers receive `cliflags.Flags`, never `*cli.Context` directly.
 - **Shared cmd parsing** (`pkg/chaos/{netem,iptables}/parse.go::ParseRequestBase`): per-action cmd parsers (`delay.go`, `loss.go`, …) call `ParseRequestBase` first to read parent-level flags via `c.Parent()` and build the populated base request (`*NetemRequest` for netem; iptables returns a small `RequestBase` carrying `*IPTablesRequest` + iface/protocol/limit). Per-action parsers then fill only their action-specific fields. New netem/iptables subcommands MUST follow this pattern — never re-parse the parent flag set inline.
 - **CLI flags adapter** (`pkg/chaos/cliflags/`): `Flags` interface wraps `urfave/cli` v1 via `V1`. Future v3 migration is a one-file swap (`v3.go` + wiring change in `cmd/main.go`).
 - **Docker runtime** (`pkg/runtime/docker/`): Docker SDK implementation of container.Client; split per-concern across `client.go`, `http_client.go`, `inspect.go`, `lifecycle.go`, `exec.go`, `sidecar.go`, `netem.go`, `iptables.go`, `stress.go`, `cgroup.go`, `pull.go` (no monolith — every file < 350 LOC)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Pumba targets **Linux containers** — every chaos action depends on Linux primi
 | **Network Delay**   | `netem delay`                             | Add latency to egress traffic                                                 |
 | **Packet Loss**     | `netem loss`, `iptables loss`             | Drop packets (egress and ingress)                                             |
 | **Network Effects** | `netem duplicate`, `corrupt`, `rate`      | Duplicate, corrupt, or rate-limit packets                                     |
+| **Combined Effects** | `netem combine`                           | Apply multiple effects in one owned netem qdisc                               |
 | **Stress Testing**  | `stress`                                  | CPU, memory, I/O stress via stress-ng (child cgroup or same-cgroup injection) |
 | **Targeting**       | names, regex (`re2:`), labels, `--random` | Flexible container selection                                                  |
 | **Scheduling**      | `--interval`                              | Recurring chaos at fixed intervals                                            |
@@ -95,6 +96,9 @@ pumba --interval=30s --random kill "re2:^test"
 
 # Add 3 seconds network delay to mydb for 5 minutes
 pumba netem --duration 5m delay --time 3000 mydb
+
+# Combine 100ms delay and 20% packet loss in one qdisc
+pumba netem --duration 5m combine --delay --delay-time 100 --loss --loss-percent 20 -- mydb
 
 # Drop 10% of incoming packets to myapp for 2 minutes
 pumba iptables --duration 2m loss --probability 0.1 myapp

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -62,8 +62,9 @@ func initializeCLICommands(runtime chaos.Runtime) []cli.Command {
 			},
 			Usage:       "emulate the properties of wide area networks",
 			ArgsUsage:   fmt.Sprintf("containers (names and RE2 regexes prefixed with %q; may be mixed)", re2Prefix),
-			Description: "delay, loss, duplicate and re-order (run 'netem') packets, and limit the bandwidth, to emulate different network problems",
+			Description: "delay, loss, duplicate and re-order packets, limit bandwidth, or combine effects in one netem qdisc",
 			Subcommands: []cli.Command{
+				*netemCmd.NewCombineCLICommand(topContext, runtime),
 				*netemCmd.NewDelayCLICommand(topContext, runtime),
 				*netemCmd.NewLossCLICommand(topContext, runtime),
 				*netemCmd.NewLossStateCLICommand(topContext, runtime),

--- a/docs/network-chaos.md
+++ b/docs/network-chaos.md
@@ -202,6 +202,42 @@ pumba netem --duration 10m rate --rate 1mbit --packetoverhead 20 mydb
 
 Options: `--rate` (e.g., `100kbit`, `1mbit`), `--packetoverhead` (bytes), `--cellsize` (bytes), `--celloverhead` (bytes).
 
+### combine
+
+Apply two or more effects in one owned netem qdisc. Enable each effect with its
+switch, then set its namespaced options. Put `--` before container selectors so
+they cannot be confused with effect flags.
+
+```bash
+# 100ms delay with 20% packet loss
+pumba netem --duration 5m combine \
+  --delay --delay-time 100 \
+  --loss --loss-percent 20 \
+  -- mydb
+
+# Delay, corruption, duplication, and a 1mbit rate limit
+pumba netem --duration 10m combine \
+  --delay --delay-time 100 --delay-jitter 20 \
+  --corrupt --corrupt-percent 5 \
+  --duplicate --duplicate-percent 2 \
+  --rate --rate-value 1mbit \
+  -- myapp
+```
+
+Supported switches and option prefixes:
+
+| Switch        | Options                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `--delay`     | `--delay-time`, `--delay-jitter`, `--delay-correlation`, `--delay-distribution`           |
+| `--loss`      | `--loss-percent`, `--loss-correlation`                                                     |
+| `--corrupt`   | `--corrupt-percent`, `--corrupt-correlation`                                               |
+| `--duplicate` | `--duplicate-percent`, `--duplicate-correlation`                                           |
+| `--rate`      | `--rate-value`, `--rate-packet-overhead`, `--rate-cell-size`, `--rate-cell-overhead`       |
+
+`combine` requires at least two effect switches. Existing single-effect commands
+remain unchanged. Stateful loss models (`loss-state` and `loss-gemodel`) are not
+part of `combine`; use them as standalone commands.
+
 ## IPTables Commands
 
 The `iptables` command manipulates **incoming** traffic by adding packet filtering rules. All iptables commands support these common options:

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,17 @@
 1. On the right bottom screen, run Pod in interactive mode: `./k8s_delay_demo.sh` - Pod pings `1.1.1.1`
 1. On the top screen, deploy `pumba` DaemonSet with two commands running `pause` and `delay`
 
+## Combined netem effects
+
+Use `netem combine` when several egress effects must share one qdisc:
+
+```bash
+pumba netem --duration 5m combine \
+  --delay --delay-time 100 \
+  --loss --loss-percent 20 \
+  -- combined-client
+```
+
 ## Combined tc and iptables demo: Asymmetric network degradation
 
 This demo shows how to create a more realistic network chaos scenario by combining both outgoing and incoming traffic manipulation:

--- a/pkg/chaos/cliflags/flags.go
+++ b/pkg/chaos/cliflags/flags.go
@@ -21,6 +21,7 @@ type Flags interface {
 	Int(name string) int
 	Float64(name string) float64
 	StringSlice(name string) []string
+	IsSet(name string) bool
 	Args() []string
 	// Parent returns the parent subcommand's flags, or nil at the root.
 	// Used by netem/iptables subcommand parsers to read flags declared on

--- a/pkg/chaos/cliflags/flags.go
+++ b/pkg/chaos/cliflags/flags.go
@@ -21,7 +21,6 @@ type Flags interface {
 	Int(name string) int
 	Float64(name string) float64
 	StringSlice(name string) []string
-	IsSet(name string) bool
 	Args() []string
 	// Parent returns the parent subcommand's flags, or nil at the root.
 	// Used by netem/iptables subcommand parsers to read flags declared on

--- a/pkg/chaos/cliflags/v1.go
+++ b/pkg/chaos/cliflags/v1.go
@@ -47,6 +47,9 @@ func (f V1) Float64(name string) float64 { return f.Ctx.Float64(name) }
 // StringSlice returns the value of the named string-slice flag.
 func (f V1) StringSlice(name string) []string { return f.Ctx.StringSlice(name) }
 
+// IsSet reports whether the named flag was explicitly provided.
+func (f V1) IsSet(name string) bool { return f.Ctx.IsSet(name) }
+
 // Args returns positional arguments as a plain []string.
 func (f V1) Args() []string { return []string(f.Ctx.Args()) }
 

--- a/pkg/chaos/netem/cmd/combine.go
+++ b/pkg/chaos/netem/cmd/combine.go
@@ -89,12 +89,17 @@ func validateCombineSwitches(c cliflags.Flags) error {
 			continue
 		}
 		for _, name := range check.flags {
-			if c.IsSet(name) {
+			if isFlagSet(c, name) {
 				return fmt.Errorf("--%s requires --%s", name, check.effect)
 			}
 		}
 	}
 	return nil
+}
+
+func isFlagSet(c cliflags.Flags, name string) bool {
+	tracker, ok := c.(interface{ IsSet(string) bool })
+	return ok && tracker.IsSet(name)
 }
 
 func combineFlags() []cli.Flag {

--- a/pkg/chaos/netem/cmd/combine.go
+++ b/pkg/chaos/netem/cmd/combine.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/chaos/cliflags"
+	chaoscmd "github.com/alexei-led/pumba/pkg/chaos/cmd"
+	"github.com/alexei-led/pumba/pkg/chaos/netem"
+	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/urfave/cli"
+)
+
+// CombineParams holds parameters for the explicit netem combine command.
+type CombineParams struct {
+	Base    *container.NetemRequest
+	Limit   int
+	Effects netem.CombinedSpec
+}
+
+// NewCombineCLICommand initializes the explicit combined-effects command.
+func NewCombineCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command {
+	return chaoscmd.NewAction(ctx, runtime, chaoscmd.Spec[CombineParams]{
+		Name:        "combine",
+		Flags:       combineFlags(),
+		Usage:       "apply two or more effects in one netem qdisc",
+		ArgsUsage:   fmt.Sprintf("-- containers (name, list of names, or RE2 regex if prefixed with %q)", chaos.Re2Prefix),
+		Description: "enable effects with --delay, --loss, --corrupt, --duplicate, and --rate; place containers after --",
+		Parse:       parseCombineParams,
+		Build:       buildCombineCommand,
+	})
+}
+
+func parseCombineParams(c cliflags.Flags, gp *chaos.GlobalParams) (CombineParams, error) {
+	base, limit, err := netem.ParseRequestBase(c.Parent(), gp)
+	if err != nil {
+		return CombineParams{}, fmt.Errorf("error parsing netem parameters: %w", err)
+	}
+	if err := validateCombineSwitches(c); err != nil {
+		return CombineParams{}, err
+	}
+	return CombineParams{Base: base, Limit: limit, Effects: combinedSpec(c)}, nil
+}
+
+func buildCombineCommand(client container.Client, gp *chaos.GlobalParams, p CombineParams) (chaos.Command, error) {
+	return netem.NewCombinedCommand(client, gp, p.Base, p.Limit, p.Effects)
+}
+
+func combinedSpec(c cliflags.Flags) netem.CombinedSpec {
+	var spec netem.CombinedSpec
+	if c.Bool("delay") {
+		spec.Delay = &netem.DelayEffect{
+			Time: c.Int("delay-time"), Jitter: c.Int("delay-jitter"),
+			Correlation: c.Float64("delay-correlation"), Distribution: c.String("delay-distribution"),
+		}
+	}
+	if c.Bool("loss") {
+		spec.Loss = &netem.LossEffect{Percent: c.Float64("loss-percent"), Correlation: c.Float64("loss-correlation")}
+	}
+	if c.Bool("corrupt") {
+		spec.Corrupt = &netem.CorruptEffect{Percent: c.Float64("corrupt-percent"), Correlation: c.Float64("corrupt-correlation")}
+	}
+	if c.Bool("duplicate") {
+		spec.Duplicate = &netem.DuplicateEffect{Percent: c.Float64("duplicate-percent"), Correlation: c.Float64("duplicate-correlation")}
+	}
+	if c.Bool("rate") {
+		spec.Rate = &netem.RateEffect{
+			Rate: c.String("rate-value"), PacketOverhead: c.Int("rate-packet-overhead"),
+			CellSize: c.Int("rate-cell-size"), CellOverhead: c.Int("rate-cell-overhead"),
+		}
+	}
+	return spec
+}
+
+func validateCombineSwitches(c cliflags.Flags) error {
+	checks := []struct {
+		effect string
+		flags  []string
+	}{
+		{effect: "delay", flags: []string{"delay-time", "delay-jitter", "delay-correlation", "delay-distribution"}},
+		{effect: "loss", flags: []string{"loss-percent", "loss-correlation"}},
+		{effect: "corrupt", flags: []string{"corrupt-percent", "corrupt-correlation"}},
+		{effect: "duplicate", flags: []string{"duplicate-percent", "duplicate-correlation"}},
+		{effect: "rate", flags: []string{"rate-value", "rate-packet-overhead", "rate-cell-size", "rate-cell-overhead"}},
+	}
+	for _, check := range checks {
+		if c.Bool(check.effect) {
+			continue
+		}
+		for _, name := range check.flags {
+			if c.IsSet(name) {
+				return fmt.Errorf("--%s requires --%s", name, check.effect)
+			}
+		}
+	}
+	return nil
+}
+
+func combineFlags() []cli.Flag {
+	flags := delayCombineFlags()
+	flags = append(flags, lossCombineFlags()...)
+	flags = append(flags, corruptCombineFlags()...)
+	flags = append(flags, duplicateCombineFlags()...)
+	return append(flags, rateCombineFlags()...)
+}
+
+func delayCombineFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "delay", Usage: "enable delay"},
+		cli.IntFlag{Name: "delay-time", Usage: "delay time in milliseconds", Value: defaultDelayTime},
+		cli.IntFlag{Name: "delay-jitter", Usage: "delay jitter in milliseconds", Value: defaultDelayJitter},
+		cli.Float64Flag{Name: "delay-correlation", Usage: "delay correlation percentage", Value: defaultDelayCorrelation},
+		cli.StringFlag{Name: "delay-distribution", Usage: "delay distribution: uniform, normal, pareto, or paretonormal"},
+	}
+}
+
+func lossCombineFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "loss", Usage: "enable random packet loss"},
+		cli.Float64Flag{Name: "loss-percent", Usage: "packet loss percentage"},
+		cli.Float64Flag{Name: "loss-correlation", Usage: "loss correlation percentage"},
+	}
+}
+
+func corruptCombineFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "corrupt", Usage: "enable packet corruption"},
+		cli.Float64Flag{Name: "corrupt-percent", Usage: "packet corruption percentage"},
+		cli.Float64Flag{Name: "corrupt-correlation", Usage: "corruption correlation percentage"},
+	}
+}
+
+func duplicateCombineFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "duplicate", Usage: "enable packet duplication"},
+		cli.Float64Flag{Name: "duplicate-percent", Usage: "packet duplication percentage"},
+		cli.Float64Flag{Name: "duplicate-correlation", Usage: "duplication correlation percentage"},
+	}
+}
+
+func rateCombineFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "rate", Usage: "enable rate limiting"},
+		cli.StringFlag{Name: "rate-value", Usage: "target egress rate", Value: defaultRate},
+		cli.IntFlag{Name: "rate-packet-overhead", Usage: "per-packet overhead in bytes"},
+		cli.IntFlag{Name: "rate-cell-size", Usage: "simulated link-layer cell size"},
+		cli.IntFlag{Name: "rate-cell-overhead", Usage: "per-cell overhead in bytes"},
+	}
+}

--- a/pkg/chaos/netem/cmd/combine_test.go
+++ b/pkg/chaos/netem/cmd/combine_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/alexei-led/pumba/pkg/chaos/cliflags"
 	"github.com/alexei-led/pumba/pkg/chaos/netem"
+	"github.com/alexei-led/pumba/pkg/container"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
 )
 
 func TestNewCombineCLICommandContract(t *testing.T) {
@@ -16,6 +19,24 @@ func TestNewCombineCLICommandContract(t *testing.T) {
 
 	assertConstructorContract(t, cmd, "combine")
 	assert.Equal(t, 0, *calls)
+}
+
+func TestCombineCLIActionParsesContainerAfterSeparator(t *testing.T) {
+	runtime, client, calls := fakeRuntime(t)
+	cmd := NewCombineCLICommand(context.Background(), runtime)
+	parent := netemContext(t, nil)
+	ctx := childContext(t, parent, cmd.Flags, []string{
+		"--delay", "--delay-time", "100",
+		"--loss", "--loss-percent", "10",
+		"--", "target",
+	})
+	client.EXPECT().ListContainers(mock.Anything, mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return(nil, nil)
+
+	action, ok := cmd.Action.(func(*cli.Context) error)
+	require.True(t, ok)
+	require.NoError(t, action(ctx))
+	assert.Equal(t, 1, *calls)
 }
 
 func TestParseCombineParams(t *testing.T) {

--- a/pkg/chaos/netem/cmd/combine_test.go
+++ b/pkg/chaos/netem/cmd/combine_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alexei-led/pumba/pkg/chaos/cliflags"
+	"github.com/alexei-led/pumba/pkg/chaos/netem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCombineCLICommandContract(t *testing.T) {
+	runtime, _, calls := fakeRuntime(t)
+	cmd := NewCombineCLICommand(context.Background(), runtime)
+
+	assertConstructorContract(t, cmd, "combine")
+	assert.Equal(t, 0, *calls)
+}
+
+func TestParseCombineParams(t *testing.T) {
+	cmd := NewCombineCLICommand(context.Background(), nilRuntime())
+	parent := netemContext(t, []string{"--duration", "1s", "--interface", "eth0", "--target", "peer"})
+	ctx := childContext(t, parent, cmd.Flags, []string{
+		"--delay", "--delay-time", "200", "--delay-jitter", "50",
+		"--loss", "--loss-percent", "10",
+		"--corrupt", "--corrupt-percent", "2",
+		"--duplicate", "--duplicate-percent", "3",
+		"--rate", "--rate-value", "1mbit",
+		"--", "target",
+	})
+
+	params, err := parseCombineParams(cliflags.NewV1(ctx), defaultGlobalParams())
+
+	require.NoError(t, err)
+	require.NotNil(t, params.Effects.Delay)
+	assert.Equal(t, 200, params.Effects.Delay.Time)
+	assert.Equal(t, 50, params.Effects.Delay.Jitter)
+	require.NotNil(t, params.Effects.Loss)
+	assert.InDelta(t, 10.0, params.Effects.Loss.Percent, 0.001)
+	require.NotNil(t, params.Effects.Corrupt)
+	require.NotNil(t, params.Effects.Duplicate)
+	require.NotNil(t, params.Effects.Rate)
+	assert.Equal(t, "1mbit", params.Effects.Rate.Rate)
+	assert.Equal(t, []string{"peer"}, params.Base.TargetNames)
+	assert.Equal(t, []string{"target"}, []string(ctx.Args()))
+}
+
+func TestParseCombineParamsRequiresEffectSwitchForParameters(t *testing.T) {
+	cmd := NewCombineCLICommand(context.Background(), nilRuntime())
+	parent := netemContext(t, nil)
+	ctx := childContext(t, parent, cmd.Flags, []string{
+		"--delay-time", "200",
+		"--loss", "--loss-percent", "10",
+		"target",
+	})
+
+	_, err := parseCombineParams(cliflags.NewV1(ctx), defaultGlobalParams())
+
+	require.ErrorContains(t, err, "--delay-time requires --delay")
+}
+
+func TestBuildCombineCommandRequiresTwoEffects(t *testing.T) {
+	_, err := buildCombineCommand(nil, defaultGlobalParams(), CombineParams{
+		Effects: netem.CombinedSpec{Loss: &netem.LossEffect{Percent: 10}},
+	})
+
+	require.ErrorContains(t, err, "at least two")
+}

--- a/pkg/chaos/netem/cmd/defaults.go
+++ b/pkg/chaos/netem/cmd/defaults.go
@@ -1,0 +1,8 @@
+package cmd
+
+const (
+	defaultDelayTime        = 100
+	defaultDelayJitter      = 10
+	defaultDelayCorrelation = 20.0
+	defaultRate             = "100kbit"
+)

--- a/pkg/chaos/netem/cmd/delay.go
+++ b/pkg/chaos/netem/cmd/delay.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Generic NewAction[P] enforces a uniform per-command shape; the residual similarity is intentional, not copy-paste.
 package cmd
 
 import (

--- a/pkg/chaos/netem/cmd/delay.go
+++ b/pkg/chaos/netem/cmd/delay.go
@@ -31,17 +31,17 @@ func NewDelayCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command
 			cli.IntFlag{
 				Name:  "time, t",
 				Usage: "delay time; in milliseconds",
-				Value: 100, //nolint:mnd
+				Value: defaultDelayTime,
 			},
 			cli.IntFlag{
 				Name:  "jitter, j",
 				Usage: "random delay variation (jitter); in milliseconds; example: 100ms ± 10ms",
-				Value: 10, //nolint:mnd
+				Value: defaultDelayJitter,
 			},
 			cli.Float64Flag{
 				Name:  "correlation, c",
 				Usage: "delay correlation; in percentage",
-				Value: 20, //nolint:mnd
+				Value: defaultDelayCorrelation,
 			},
 			cli.StringFlag{
 				Name:  "distribution, d",

--- a/pkg/chaos/netem/cmd/loss_ge.go
+++ b/pkg/chaos/netem/cmd/loss_ge.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Generic NewAction[P] enforces a uniform per-command shape; the residual similarity is intentional, not copy-paste.
 package cmd
 
 import (

--- a/pkg/chaos/netem/cmd/rate.go
+++ b/pkg/chaos/netem/cmd/rate.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Generic NewAction[P] enforces a uniform per-command shape; the residual similarity is intentional, not copy-paste.
 package cmd
 
 import (

--- a/pkg/chaos/netem/cmd/rate.go
+++ b/pkg/chaos/netem/cmd/rate.go
@@ -31,7 +31,7 @@ func NewRateCLICommand(ctx context.Context, runtime chaos.Runtime) *cli.Command 
 			cli.StringFlag{
 				Name:  "rate, r",
 				Usage: "delay outgoing packets; in common units",
-				Value: "100kbit",
+				Value: defaultRate,
 			},
 			cli.IntFlag{
 				Name:  "packetoverhead, p",

--- a/pkg/chaos/netem/combine.go
+++ b/pkg/chaos/netem/combine.go
@@ -81,7 +81,7 @@ func (s CombinedSpec) validate() error {
 		}
 	}
 	if s.Rate != nil {
-		if err := validateRateParams(s.Rate.Rate, s.Rate.CellSize); err != nil {
+		if err := validateRateParams(s.Rate.Rate, s.Rate.CellSize, s.Rate.CellOverhead); err != nil {
 			return err
 		}
 	}

--- a/pkg/chaos/netem/combine.go
+++ b/pkg/chaos/netem/combine.go
@@ -1,0 +1,166 @@
+package netem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/container"
+	log "github.com/sirupsen/logrus"
+)
+
+const minimumCombinedEffects = 2
+
+// DelayEffect configures delay within a combined netem qdisc.
+type DelayEffect struct {
+	Time         int
+	Jitter       int
+	Correlation  float64
+	Distribution string
+}
+
+// LossEffect configures random packet loss within a combined netem qdisc.
+type LossEffect struct {
+	Percent     float64
+	Correlation float64
+}
+
+// CorruptEffect configures packet corruption within a combined netem qdisc.
+type CorruptEffect struct {
+	Percent     float64
+	Correlation float64
+}
+
+// DuplicateEffect configures packet duplication within a combined netem qdisc.
+type DuplicateEffect struct {
+	Percent     float64
+	Correlation float64
+}
+
+// RateEffect configures rate limiting within a combined netem qdisc.
+type RateEffect struct {
+	Rate           string
+	PacketOverhead int
+	CellSize       int
+	CellOverhead   int
+}
+
+// CombinedSpec selects effects for one netem qdisc. At least two effects must
+// be enabled; use the existing single-effect commands otherwise.
+type CombinedSpec struct {
+	Delay     *DelayEffect
+	Loss      *LossEffect
+	Corrupt   *CorruptEffect
+	Duplicate *DuplicateEffect
+	Rate      *RateEffect
+}
+
+func (s CombinedSpec) validate() error {
+	if s.effectCount() < minimumCombinedEffects {
+		return errors.New("at least two netem effects are required; use a single-effect command for one")
+	}
+	if s.Delay != nil {
+		if err := validateDelay(s.Delay.Time, s.Delay.Jitter, s.Delay.Correlation, s.Delay.Distribution); err != nil {
+			return err
+		}
+	}
+	if s.Loss != nil {
+		if err := validateLoss(s.Loss.Percent, s.Loss.Correlation); err != nil {
+			return err
+		}
+	}
+	if s.Duplicate != nil {
+		if err := validateDuplicate(s.Duplicate.Percent, s.Duplicate.Correlation); err != nil {
+			return err
+		}
+	}
+	if s.Corrupt != nil {
+		if err := validateCorrupt(s.Corrupt.Percent, s.Corrupt.Correlation); err != nil {
+			return err
+		}
+	}
+	if s.Rate != nil {
+		if err := validateRateParams(s.Rate.Rate, s.Rate.CellSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s CombinedSpec) effectCount() int {
+	count := 0
+	for _, enabled := range []bool{
+		s.Delay != nil,
+		s.Loss != nil,
+		s.Corrupt != nil,
+		s.Duplicate != nil,
+		s.Rate != nil,
+	} {
+		if enabled {
+			count++
+		}
+	}
+	return count
+}
+
+func (s CombinedSpec) args() []string {
+	var args []string
+	if s.Delay != nil {
+		args = append(args, delayArgs(s.Delay.Time, s.Delay.Jitter, s.Delay.Correlation, s.Delay.Distribution)...)
+	}
+	if s.Loss != nil {
+		args = append(args, lossArgs(s.Loss.Percent, s.Loss.Correlation)...)
+	}
+	if s.Duplicate != nil {
+		args = append(args, duplicateArgs(s.Duplicate.Percent, s.Duplicate.Correlation)...)
+	}
+	if s.Corrupt != nil {
+		args = append(args, corruptArgs(s.Corrupt.Percent, s.Corrupt.Correlation)...)
+	}
+	if s.Rate != nil {
+		args = append(args, rateArgs(s.Rate.Rate, s.Rate.PacketOverhead, s.Rate.CellSize, s.Rate.CellOverhead)...)
+	}
+	return args
+}
+
+type combinedCommand struct {
+	client netemClient
+	gp     *chaos.GlobalParams
+	req    *container.NetemRequest
+	limit  int
+	spec   CombinedSpec
+}
+
+// NewCombinedCommand creates one command that applies multiple effects in one
+// owned netem qdisc.
+func NewCombinedCommand(client netemClient, gp *chaos.GlobalParams, req *container.NetemRequest, limit int, spec CombinedSpec) (chaos.Command, error) {
+	if err := spec.validate(); err != nil {
+		return nil, err
+	}
+	return &combinedCommand{client: client, gp: gp, req: req, limit: limit, spec: spec}, nil
+}
+
+func (n *combinedCommand) Run(ctx context.Context, random bool) error {
+	resolvedReq, err := resolveRequestTargets(ctx, n.client, n.req)
+	if err != nil {
+		return fmt.Errorf("failed to resolve --target: %w", err)
+	}
+	command := n.spec.args()
+	log.WithFields(log.Fields{
+		"names": n.gp.Names, "pattern": n.gp.Pattern, "labels": n.gp.Labels,
+		"limit": n.limit, "random": random, "command": command,
+	}).Debug("adding combined network effects to matching containers")
+	return chaos.RunOnContainers(ctx, n.client, n.gp, n.limit, random, true,
+		func(ctx context.Context, target *container.Container) error {
+			netemCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			req := *resolvedReq
+			req.Container = target
+			req.Command = command
+			if err := runNetem(netemCtx, n.client, &req); err != nil {
+				return fmt.Errorf("failed to apply combined network effects: %w", err)
+			}
+			return nil
+		})
+}

--- a/pkg/chaos/netem/combine_test.go
+++ b/pkg/chaos/netem/combine_test.go
@@ -81,7 +81,7 @@ func TestCombinedCommandRunBuildsOneNetemCommand(t *testing.T) {
 			"loss", "10.00", "5.00",
 			"duplicate", "3.00",
 			"corrupt", "1.00",
-			"rate", "100kbit",
+			"rate", "100kbit", "0", "53",
 		},
 		Duration: time.Millisecond,
 		DryRun:   true,
@@ -94,7 +94,7 @@ func TestCombinedCommandRunBuildsOneNetemCommand(t *testing.T) {
 		Loss:      &LossEffect{Percent: 10, Correlation: 5},
 		Duplicate: &DuplicateEffect{Percent: 3},
 		Corrupt:   &CorruptEffect{Percent: 1},
-		Rate:      &RateEffect{Rate: "100kbit"},
+		Rate:      &RateEffect{Rate: "100kbit", CellSize: 53},
 	})
 	require.NoError(t, err)
 

--- a/pkg/chaos/netem/combine_test.go
+++ b/pkg/chaos/netem/combine_test.go
@@ -1,0 +1,166 @@
+package netem
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alexei-led/pumba/pkg/chaos"
+	"github.com/alexei-led/pumba/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCombinedCommandValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    CombinedSpec
+		wantErr string
+	}{
+		{name: "no effects", wantErr: "at least two"},
+		{name: "one effect", spec: CombinedSpec{Delay: &DelayEffect{Time: 100}}, wantErr: "at least two"},
+		{
+			name:    "invalid delay",
+			spec:    CombinedSpec{Delay: &DelayEffect{Time: -1}, Loss: &LossEffect{Percent: 10}},
+			wantErr: "non-positive delay",
+		},
+		{
+			name:    "invalid loss",
+			spec:    CombinedSpec{Delay: &DelayEffect{Time: 100}, Loss: &LossEffect{Percent: 101}},
+			wantErr: "invalid loss percent",
+		},
+		{
+			name:    "invalid corrupt",
+			spec:    CombinedSpec{Delay: &DelayEffect{Time: 100}, Corrupt: &CorruptEffect{Percent: -1}},
+			wantErr: "invalid corrupt percent",
+		},
+		{
+			name:    "invalid duplicate",
+			spec:    CombinedSpec{Delay: &DelayEffect{Time: 100}, Duplicate: &DuplicateEffect{Correlation: 101}},
+			wantErr: "invalid duplicate correlation",
+		},
+		{
+			name:    "invalid rate",
+			spec:    CombinedSpec{Delay: &DelayEffect{Time: 100}, Rate: &RateEffect{Rate: "invalid"}},
+			wantErr: "invalid rate",
+		},
+		{
+			name: "valid effects",
+			spec: CombinedSpec{Delay: &DelayEffect{Time: 100}, Loss: &LossEffect{Percent: 20}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := NewCombinedCommand(nil, &chaos.GlobalParams{}, &container.NetemRequest{}, 0, tt.spec)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, cmd)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, cmd)
+		})
+	}
+}
+
+func TestCombinedCommandRunBuildsOneNetemCommand(t *testing.T) {
+	client := container.NewMockClient(t)
+	target := &container.Container{ContainerID: "target-id", ContainerName: "target"}
+	gp := &chaos.GlobalParams{Names: []string{"target"}, DryRun: true}
+	req := &container.NetemRequest{Interface: "eth0", Duration: time.Millisecond, DryRun: true}
+	client.EXPECT().ListContainers(mock.Anything, mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{target}, nil)
+	expected := &container.NetemRequest{
+		Container: target,
+		Interface: "eth0",
+		Command: []string{
+			"delay", "200ms", "50ms", "25.50", "distribution", "normal",
+			"loss", "10.00", "5.00",
+			"duplicate", "3.00",
+			"corrupt", "1.00",
+			"rate", "100kbit",
+		},
+		Duration: time.Millisecond,
+		DryRun:   true,
+	}
+	client.EXPECT().NetemContainer(mock.Anything, expected).Return(nil)
+	client.EXPECT().StopNetemContainer(mock.Anything, expected).Return(nil)
+
+	cmd, err := NewCombinedCommand(client, gp, req, 0, CombinedSpec{
+		Delay:     &DelayEffect{Time: 200, Jitter: 50, Correlation: 25.5, Distribution: "normal"},
+		Loss:      &LossEffect{Percent: 10, Correlation: 5},
+		Duplicate: &DuplicateEffect{Percent: 3},
+		Corrupt:   &CorruptEffect{Percent: 1},
+		Rate:      &RateEffect{Rate: "100kbit"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Run(context.Background(), false))
+}
+
+func TestCombinedCommandRunResolvesNamedTrafficTarget(t *testing.T) {
+	client := container.NewMockClient(t)
+	peer := &container.Container{
+		ContainerID: "peer-id", ContainerName: "peer",
+		Networks: map[string]container.NetworkLink{"bridge": {IPv4Address: "10.0.0.9"}},
+	}
+	target := &container.Container{ContainerID: "target-id", ContainerName: "target"}
+	gp := &chaos.GlobalParams{Names: []string{"target"}, DryRun: true}
+	req := &container.NetemRequest{TargetNames: []string{"peer"}, Duration: time.Millisecond, DryRun: true}
+	client.EXPECT().ListContainers(mock.Anything, mock.Anything, container.ListOpts{All: false}).
+		Return([]*container.Container{peer, target}, nil).Once()
+	client.EXPECT().ListContainers(mock.Anything, mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{target}, nil).Once()
+	combinedRequest := mock.MatchedBy(func(actual *container.NetemRequest) bool {
+		return len(actual.IPs) == 1 && actual.IPs[0].String() == "10.0.0.9/32" && len(actual.TargetNames) == 0
+	})
+	client.EXPECT().NetemContainer(mock.Anything, combinedRequest).Return(nil)
+	client.EXPECT().StopNetemContainer(mock.Anything, combinedRequest).Return(nil)
+	cmd, err := NewCombinedCommand(client, gp, req, 0, CombinedSpec{
+		Delay: &DelayEffect{Time: 100},
+		Loss:  &LossEffect{Percent: 10},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Run(context.Background(), false))
+}
+
+func TestCombinedCommandRunWithRandom(t *testing.T) {
+	client := container.NewMockClient(t)
+	first := &container.Container{ContainerID: "first-id", ContainerName: "first"}
+	second := &container.Container{ContainerID: "second-id", ContainerName: "second"}
+	gp := &chaos.GlobalParams{Names: []string{"first", "second"}, DryRun: true}
+	req := &container.NetemRequest{Duration: time.Millisecond, DryRun: true}
+	client.EXPECT().ListContainers(mock.Anything, mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return([]*container.Container{first, second}, nil)
+	combinedRequest := mock.MatchedBy(func(actual *container.NetemRequest) bool {
+		return (actual.Container == first || actual.Container == second) &&
+			slices.Equal([]string{"delay", "100ms", "loss", "10.00"}, actual.Command)
+	})
+	client.EXPECT().NetemContainer(mock.Anything, combinedRequest).Return(nil).Once()
+	client.EXPECT().StopNetemContainer(mock.Anything, combinedRequest).Return(nil).Once()
+	cmd, err := NewCombinedCommand(client, gp, req, 0, CombinedSpec{
+		Delay: &DelayEffect{Time: 100},
+		Loss:  &LossEffect{Percent: 10},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Run(context.Background(), true))
+}
+
+func TestCombinedCommandRunNoContainers(t *testing.T) {
+	client := container.NewMockClient(t)
+	gp := &chaos.GlobalParams{Names: []string{"missing"}}
+	client.EXPECT().ListContainers(mock.Anything, mock.AnythingOfType("container.FilterFunc"), container.ListOpts{All: false}).
+		Return(nil, nil)
+	cmd, err := NewCombinedCommand(client, gp, &container.NetemRequest{}, 0, CombinedSpec{
+		Delay: &DelayEffect{Time: 100},
+		Loss:  &LossEffect{Percent: 10},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Run(context.Background(), false))
+}

--- a/pkg/chaos/netem/corrupt.go
+++ b/pkg/chaos/netem/corrupt.go
@@ -21,6 +21,24 @@ type corruptCommand struct {
 	correlation float64
 }
 
+func validateCorrupt(percent, correlation float64) error {
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid corrupt percent: must be between 0.0 and 100.0")
+	}
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid corrupt correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+func corruptArgs(percent, correlation float64) []string {
+	cmd := []string{"corrupt", strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewCorruptCommand create new netem corrupt command
 func NewCorruptCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -29,13 +47,8 @@ func NewCorruptCommand(client netemClient,
 	percent, // corrupt percent
 	correlation float64, // corrupt correlation
 ) (chaos.Command, error) {
-	// get netem corrupt percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid corrupt percent: must be between 0.0 and 100.0")
-	}
-	// get netem corrupt variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid corrupt correlation: must be between 0.0 and 100.0")
+	if err := validateCorrupt(percent, correlation); err != nil {
+		return nil, err
 	}
 	return &corruptCommand{
 		client:      client,
@@ -84,9 +97,5 @@ func (n *corruptCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *corruptCommand) buildNetemCmd() []string {
-	cmd := []string{"corrupt", strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return corruptArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -47,7 +47,7 @@ func validateDelay(delay, jitter int, correlation float64, distribution string) 
 
 func delayArgs(delay, jitter int, correlation float64, distribution string) []string {
 	cmd := []string{"delay", strconv.Itoa(delay) + "ms"}
-	if jitter > 0 {
+	if jitter > 0 || correlation > 0 || distribution != "" {
 		cmd = append(cmd, strconv.Itoa(jitter)+"ms")
 	}
 	if correlation > 0 {

--- a/pkg/chaos/netem/delay.go
+++ b/pkg/chaos/netem/delay.go
@@ -29,6 +29,36 @@ type delayCommand struct {
 	distribution string
 }
 
+func validateDelay(delay, jitter int, correlation float64, distribution string) error {
+	if delay <= 0 {
+		return errors.New("non-positive delay time")
+	}
+	if jitter < 0 || jitter > delay {
+		return errors.New("invalid delay jitter: must be non-negative and smaller than delay time")
+	}
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid delay correlation: must be between 0.0 and 100.0")
+	}
+	if !slices.Contains(delayDistribution, distribution) {
+		return errors.New("invalid delay distribution: must be one of {uniform | normal | pareto |  paretonormal}")
+	}
+	return nil
+}
+
+func delayArgs(delay, jitter int, correlation float64, distribution string) []string {
+	cmd := []string{"delay", strconv.Itoa(delay) + "ms"}
+	if jitter > 0 {
+		cmd = append(cmd, strconv.Itoa(jitter)+"ms")
+	}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	if distribution != "" {
+		cmd = append(cmd, "distribution", distribution)
+	}
+	return cmd
+}
+
 // NewDelayCommand create new netem delay command
 func NewDelayCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -39,21 +69,8 @@ func NewDelayCommand(client netemClient,
 	correlation float64, // delay correlation
 	distribution string, // delay distribution
 ) (chaos.Command, error) {
-	// check delay time
-	if delay <= 0 {
-		return nil, errors.New("non-positive delay time")
-	}
-	// get delay variation
-	if jitter < 0 || jitter > delay {
-		return nil, errors.New("invalid delay jitter: must be non-negative and smaller than delay time")
-	}
-	// get delay variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid delay correlation: must be between 0.0 and 100.0")
-	}
-	// get distribution
-	if !slices.Contains(delayDistribution, distribution) {
-		return nil, errors.New("invalid delay distribution: must be one of {uniform | normal | pareto |  paretonormal}")
+	if err := validateDelay(delay, jitter, correlation, distribution); err != nil {
+		return nil, err
 	}
 	return &delayCommand{
 		client:       client,
@@ -102,15 +119,5 @@ func (n *delayCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *delayCommand) buildNetemCmd() []string {
-	cmd := []string{"delay", strconv.Itoa(n.time) + "ms"}
-	if n.jitter > 0 {
-		cmd = append(cmd, strconv.Itoa(n.jitter)+"ms")
-	}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	if n.distribution != "" {
-		cmd = append(cmd, []string{"distribution", n.distribution}...)
-	}
-	return cmd
+	return delayArgs(n.time, n.jitter, n.correlation, n.distribution)
 }

--- a/pkg/chaos/netem/delay_test.go
+++ b/pkg/chaos/netem/delay_test.go
@@ -102,6 +102,10 @@ func TestNewDelayCommand_Validation(t *testing.T) {
 	}
 }
 
+func TestDelayArgsPreservesCorrelationPositionWithoutJitter(t *testing.T) {
+	assert.Equal(t, []string{"delay", "100ms", "0ms", "50.00"}, delayArgs(100, 0, 50, ""))
+}
+
 func TestDelayCommand_Run_NoContainers(t *testing.T) {
 	mockClient := container.NewMockClient(t)
 	gparams := &chaos.GlobalParams{Names: []string{"nonexistent"}}

--- a/pkg/chaos/netem/duplicate.go
+++ b/pkg/chaos/netem/duplicate.go
@@ -25,6 +25,24 @@ type duplicateCommand struct {
 	correlation float64
 }
 
+func validateDuplicate(percent, correlation float64) error {
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid duplicate percent: must be between 0.0 and 100.0")
+	}
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid duplicate correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+func duplicateArgs(percent, correlation float64) []string {
+	cmd := []string{duplicateCmd, strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewDuplicateCommand create new netem duplicate command
 func NewDuplicateCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -33,13 +51,8 @@ func NewDuplicateCommand(client netemClient,
 	percent, // duplicate percent
 	correlation float64, // duplicate correlation
 ) (chaos.Command, error) {
-	// get netem duplicate percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid duplicate percent: must be between 0.0 and 100.0")
-	}
-	// get netem duplicate variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid duplicate correlation: must be between 0.0 and 100.0")
+	if err := validateDuplicate(percent, correlation); err != nil {
+		return nil, err
 	}
 	return &duplicateCommand{
 		client:      client,
@@ -88,9 +101,5 @@ func (n *duplicateCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *duplicateCommand) buildNetemCmd() []string {
-	cmd := []string{duplicateCmd, strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return duplicateArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/loss.go
+++ b/pkg/chaos/netem/loss.go
@@ -21,6 +21,24 @@ type lossCommand struct {
 	correlation float64
 }
 
+func validateLoss(percent, correlation float64) error {
+	if percent < 0.0 || percent > 100.0 {
+		return errors.New("invalid loss percent: must be between 0.0 and 100.0")
+	}
+	if correlation < 0.0 || correlation > 100.0 {
+		return errors.New("invalid loss correlation: must be between 0.0 and 100.0")
+	}
+	return nil
+}
+
+func lossArgs(percent, correlation float64) []string {
+	cmd := []string{"loss", strconv.FormatFloat(percent, 'f', 2, 64)}
+	if correlation > 0 {
+		cmd = append(cmd, strconv.FormatFloat(correlation, 'f', 2, 64))
+	}
+	return cmd
+}
+
 // NewLossCommand create new netem loss command
 func NewLossCommand(client netemClient,
 	gp *chaos.GlobalParams,
@@ -29,15 +47,9 @@ func NewLossCommand(client netemClient,
 	percent, // loss percent
 	correlation float64, // loss correlation
 ) (chaos.Command, error) {
-	// get netem loss percent
-	if percent < 0.0 || percent > 100.0 {
-		return nil, errors.New("invalid loss percent: must be between 0.0 and 100.0")
+	if err := validateLoss(percent, correlation); err != nil {
+		return nil, err
 	}
-	// get netem loss variation
-	if correlation < 0.0 || correlation > 100.0 {
-		return nil, errors.New("invalid loss correlation: must be between 0.0 and 100.0")
-	}
-
 	return &lossCommand{
 		client:      client,
 		gp:          gp,
@@ -83,9 +95,5 @@ func (n *lossCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *lossCommand) buildNetemCmd() []string {
-	cmd := []string{"loss", strconv.FormatFloat(n.percent, 'f', 2, 64)}
-	if n.correlation > 0 {
-		cmd = append(cmd, strconv.FormatFloat(n.correlation, 'f', 2, 64))
-	}
-	return cmd
+	return lossArgs(n.percent, n.correlation)
 }

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -22,6 +22,33 @@ func parseRate(rate string) (string, error) {
 	return rate, nil
 }
 
+func validateRateParams(rate string, cellSize int) error {
+	if rate == "" {
+		return errors.New("undefined rate limit")
+	}
+	if _, err := parseRate(rate); err != nil {
+		return fmt.Errorf("invalid rate: %w", err)
+	}
+	if cellSize < 0 {
+		return errors.New("invalid cell size: must be a non-negative integer")
+	}
+	return nil
+}
+
+func rateArgs(rate string, packetOverhead, cellSize, cellOverhead int) []string {
+	cmd := []string{"rate", rate}
+	if packetOverhead != 0 {
+		cmd = append(cmd, strconv.Itoa(packetOverhead))
+	}
+	if cellSize > 0 {
+		cmd = append(cmd, strconv.Itoa(cellSize))
+	}
+	if cellOverhead != 0 {
+		cmd = append(cmd, strconv.Itoa(cellOverhead))
+	}
+	return cmd
+}
+
 // `netem rate` command
 type rateCommand struct {
 	client         netemClient
@@ -44,20 +71,9 @@ func NewRateCommand(client netemClient,
 	cellSize, // cell size of the simulated link layer scheme
 	cellOverhead int, // per cell overhead; in bytes
 ) (chaos.Command, error) {
-	// validate target egress rate
-	if rate == "" {
-		return nil, errors.New("undefined rate limit")
+	if err := validateRateParams(rate, cellSize); err != nil {
+		return nil, err
 	}
-	rate, err := parseRate(rate)
-	if err != nil {
-		return nil, fmt.Errorf("invalid rate: %w", err)
-	}
-
-	// validate cell size
-	if cellSize < 0 {
-		return nil, errors.New("invalid cell size: must be a non-negative integer")
-	}
-
 	return &rateCommand{
 		client:         client,
 		gp:             gp,
@@ -108,15 +124,5 @@ func (n *rateCommand) Run(ctx context.Context, random bool) error {
 }
 
 func (n *rateCommand) buildNetemCmd() []string {
-	cmd := []string{"rate", n.rate}
-	if n.packetOverhead != 0 {
-		cmd = append(cmd, strconv.Itoa(n.packetOverhead))
-	}
-	if n.cellSize > 0 {
-		cmd = append(cmd, strconv.Itoa(n.cellSize))
-	}
-	if n.cellOverhead != 0 {
-		cmd = append(cmd, strconv.Itoa(n.cellOverhead))
-	}
-	return cmd
+	return rateArgs(n.rate, n.packetOverhead, n.cellSize, n.cellOverhead)
 }

--- a/pkg/chaos/netem/rate.go
+++ b/pkg/chaos/netem/rate.go
@@ -22,7 +22,7 @@ func parseRate(rate string) (string, error) {
 	return rate, nil
 }
 
-func validateRateParams(rate string, cellSize int) error {
+func validateRateParams(rate string, cellSize, cellOverhead int) error {
 	if rate == "" {
 		return errors.New("undefined rate limit")
 	}
@@ -32,12 +32,15 @@ func validateRateParams(rate string, cellSize int) error {
 	if cellSize < 0 {
 		return errors.New("invalid cell size: must be a non-negative integer")
 	}
+	if cellOverhead != 0 && cellSize == 0 {
+		return errors.New("cell overhead requires a positive cell size")
+	}
 	return nil
 }
 
 func rateArgs(rate string, packetOverhead, cellSize, cellOverhead int) []string {
 	cmd := []string{"rate", rate}
-	if packetOverhead != 0 {
+	if packetOverhead != 0 || cellSize > 0 {
 		cmd = append(cmd, strconv.Itoa(packetOverhead))
 	}
 	if cellSize > 0 {
@@ -71,7 +74,7 @@ func NewRateCommand(client netemClient,
 	cellSize, // cell size of the simulated link layer scheme
 	cellOverhead int, // per cell overhead; in bytes
 ) (chaos.Command, error) {
-	if err := validateRateParams(rate, cellSize); err != nil {
+	if err := validateRateParams(rate, cellSize, cellOverhead); err != nil {
 		return nil, err
 	}
 	return &rateCommand{

--- a/pkg/chaos/netem/rate_test.go
+++ b/pkg/chaos/netem/rate_test.go
@@ -38,6 +38,17 @@ func TestParseRate(t *testing.T) {
 	}
 }
 
+func TestRateArgsPreservesCellSizePositionWithoutPacketOverhead(t *testing.T) {
+	assert.Equal(t, []string{"rate", "100kbit", "0", "53"}, rateArgs("100kbit", 0, 53, 0))
+}
+
+func TestNewRateCommandRejectsCellOverheadWithoutCellSize(t *testing.T) {
+	cmd, err := NewRateCommand(nil, &chaos.GlobalParams{}, &container.NetemRequest{}, 0, "100kbit", 0, 0, 5)
+
+	require.ErrorContains(t, err, "cell overhead requires a positive cell size")
+	assert.Nil(t, cmd)
+}
+
 func TestRateCommand_Run_NoContainers(t *testing.T) {
 	mockClient := container.NewMockClient(t)
 	gparams := &chaos.GlobalParams{Names: []string{"nonexistent"}}

--- a/tests/containerd_netem.bats
+++ b/tests/containerd_netem.bats
@@ -89,6 +89,15 @@ teardown() {
     refute_output --partial "504d:"
 }
 
+@test "Should combine netem effects via containerd runtime" {
+    run sudo pumba --runtime containerd --containerd-namespace moby --log-level debug netem --interface dummy0 --pull-image=false --duration 2s combine \
+        --delay --delay-time 100 --loss --loss-percent 10 -- test-netem-ctr
+    assert_success
+
+    run sudo ctr -n moby t exec --exec-id check-combined-clean test-netem-ctr tc qdisc show dev dummy0
+    refute_output --partial "504d:"
+}
+
 @test "Should apply packet loss via containerd runtime" {
     # Run pumba in BACKGROUND with long duration
     sudo pumba --runtime containerd --containerd-namespace moby --log-level debug netem --interface dummy0 --pull-image=false --duration 30s loss --percent 50 test-netem-ctr &

--- a/tests/netem.bats
+++ b/tests/netem.bats
@@ -117,6 +117,29 @@ teardown() {
     assert_netem_cleaned "pingtest"
 }
 
+@test "Should combine delay and loss in one netem qdisc" {
+    create_test_container "pingtest" "alpine" "sleep infinity"
+    ensure_nettools_image
+
+    pumba netem --duration 5s --tc-image "${NETTOOLS_IMAGE}" --pull-image=false combine \
+        --delay --delay-time 100 --loss --loss-percent 10 -- pingtest &
+    PUMBA_PID=$!
+
+    wait_for 5 "nsenter -t \$(docker inspect -f '{{.State.Pid}}' pingtest) -n tc qdisc show dev eth0 2>/dev/null | grep -q 'delay.*loss'" "combined netem effects to be applied"
+
+    local pid
+    pid=$(docker inspect -f '{{.State.Pid}}' pingtest)
+    run nsenter -t "$pid" -n tc qdisc show dev eth0
+    assert_output --partial "delay"
+    assert_output --partial "loss"
+
+    wait "$PUMBA_PID"
+    local pumba_exit=$?
+    [ "$pumba_exit" -eq 0 ]
+    assert_netem_cleaned "pingtest"
+    assert_sidecar_cleaned
+}
+
 @test "Should validate packet loss command syntax" {
     # Given a running container to target
     create_test_container "netem_target" "alpine" "sleep infinity"

--- a/tests/podman_netem.bats
+++ b/tests/podman_netem.bats
@@ -77,6 +77,15 @@ teardown() {
     refute_output --partial "504d:"
 }
 
+@test "Should combine netem effects via podman runtime" {
+    run pumba --runtime podman --log-level debug netem --interface dummy0 --pull-image=false --duration 2s combine \
+        --delay --delay-time 100 --loss --loss-percent 10 -- pdm-netem-ctr
+    assert_success
+
+    run podman exec pdm-netem-ctr tc qdisc show dev dummy0
+    refute_output --partial "504d:"
+}
+
 @test "Should apply packet loss via podman runtime" {
     pumba --runtime podman --log-level debug netem --interface dummy0 --pull-image=false --duration 30s loss --percent 50 pdm-netem-ctr &
     PUMBA_PID=$!


### PR DESCRIPTION
Closes #115.

## Summary
- add explicit `netem combine` without changing existing subcommands
- enable delay, loss, corrupt, duplicate, and rate through namespaced flags
- require at least two effects and use `--` before container selectors
- reuse single-effect validation and tc argument generation
- preserve optional tc argument positions with explicit placeholders
- retain target-name resolution and ownership-safe qdisc cleanup
- document syntax and add Docker, Podman, and containerd integration tests

## Validation
- `CGO_ENABLED=0 go test ./...`
- `golangci-lint run -c .golangci.yaml --new-from-rev=origin/master ./...`
- focused patch coverage: netem 96.5%, netem/cmd 90.5%
- shellcheck: changed Bats code clean; existing SC2034/SC2329 findings remain elsewhere in the files
- independent review: PASS (no Critical/High/Medium findings)

Local Bats execution was unavailable because Colima/Docker is not running and the host Bats install lacks bats-support. GitHub integration jobs exercise all three runtimes.
